### PR TITLE
Add Simplified Chinese (zh_CN) translation.

### DIFF
--- a/whatpulse_zh_CN.ts
+++ b/whatpulse_zh_CN.ts
@@ -1,0 +1,5176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ts_ZA">
+<context>
+    <name>AccountTab</name>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="26"/>
+        <source>Account information</source>
+        <translation>账户信息</translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="37"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="39"/>
+        <source>UserID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="42"/>
+        <source>Computer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="44"/>
+        <source>Email:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="46"/>
+        <source>Premium:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="70"/>
+        <source>Total Keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="72"/>
+        <source>Total Clicks:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="74"/>
+        <source>Total Download:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="76"/>
+        <source>Total Upload:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="78"/>
+        <source>Total Uptime:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="132"/>
+        <source> &amp;View Online Stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="140"/>
+        <source> &amp;Log out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="148"/>
+        <source> &amp;Reset Token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="156"/>
+        <source> Change &amp;Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="165"/>
+        <source> Refresh &amp;Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="219"/>
+        <location filename="../interface/AccountTab.cpp" line="225"/>
+        <location filename="../interface/AccountTab.cpp" line="231"/>
+        <location filename="../interface/AccountTab.cpp" line="237"/>
+        <location filename="../interface/AccountTab.cpp" line="243"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="247"/>
+        <source>Yes (expires at %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="251"/>
+        <location filename="../interface/AccountTab.cpp" line="317"/>
+        <location filename="../interface/AccountTab.cpp" line="347"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="310"/>
+        <source>Log Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="312"/>
+        <source>Logging out of your account will reset your unpulsed statistics if you login to a different account (database is preserved) and restart the Setup Assistant.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="316"/>
+        <source>Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="317"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="332"/>
+        <source>Change Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="333"/>
+        <source>You can&apos;t change your password inside the client. Please log out and log back in with the same email address and computer name to change your password in this client. Your stats will be preserved if you use the same details.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="338"/>
+        <location filename="../interface/AccountTab.cpp" line="377"/>
+        <location filename="../interface/AccountTab.cpp" line="383"/>
+        <location filename="../interface/AccountTab.cpp" line="450"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="343"/>
+        <location filename="../interface/AccountTab.cpp" line="380"/>
+        <source>Reset your token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="344"/>
+        <source>Resetting your token will reset your local statistics and allow you to pulse again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="346"/>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="347"/>
+        <source>Yes, reset token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="375"/>
+        <source>Token reset!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="376"/>
+        <source>Token reset!
+
+You can continue pulsing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="381"/>
+        <source>Something went wrong while resetting your token:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="440"/>
+        <source>Premium Membership</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="441"/>
+        <source>Your premium membership has just been activated!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="447"/>
+        <source>Refresh Account Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTab.cpp" line="448"/>
+        <source>Something went wrong while refreshing your account data:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AccountTabWizard</name>
+    <message>
+        <location filename="../interface/AccountTabWizard.cpp" line="35"/>
+        <source>Finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard.cpp" line="40"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard.cpp" line="96"/>
+        <source>Welcome to WhatPulse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Application</name>
+    <message>
+        <location filename="../application.cpp" line="234"/>
+        <source>No system tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="235"/>
+        <source>Couldn&apos;t detect any system tray on this system, and I need that to run.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="253"/>
+        <source>AES functions not available. Are libeay32.dll and ssleay32.dll present? If not, try reinstalling!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="257"/>
+        <source>AES functions not available. Is OpenSSL library present?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="260"/>
+        <source>AES failure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="337"/>
+        <source>Cleanup Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="338"/>
+        <source>I have detected a required cleanup after your update of just now. For the sake of cleanliness, I will run the cleanup program (whatpulse-after-update.exe) before loading. You might get a permission authorization request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="872"/>
+        <source>&amp;Open Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="876"/>
+        <source>&amp;Toggle Geek Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="880"/>
+        <source>&amp;Open Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="884"/>
+        <source>&amp;Check for Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="888"/>
+        <source>&amp;Pulse!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="891"/>
+        <source>&amp;View Online Stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="895"/>
+        <source>&amp;Quit WhatPulse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="898"/>
+        <source>Enabled Stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="899"/>
+        <source>Keyboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="900"/>
+        <source>Keyboard Heatmap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="901"/>
+        <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="902"/>
+        <source>Mouse Heatmap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="903"/>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="904"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1349"/>
+        <source>Pulsing Disabled!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1350"/>
+        <source>The setting &quot;Work Offline&quot; is enabled. This prevents the client from going online, which includes pulsing. Disable that setting and you can pulse again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1537"/>
+        <source>You have enabled Portable Mode. This should only be used when placing WhatPulse on a portable media, like an USB drive.
+Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1540"/>
+        <location filename="../application.cpp" line="1563"/>
+        <location filename="../application.cpp" line="1579"/>
+        <location filename="../application.cpp" line="1595"/>
+        <location filename="../application.cpp" line="1638"/>
+        <location filename="../application.cpp" line="1649"/>
+        <source>Portable Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1560"/>
+        <source>Copying the database to %1 failed! Check write permissions.
+Disabling Portable Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1576"/>
+        <source>Copying the statistics file to %1 failed! Check write permissions.
+Disabling Portable Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1596"/>
+        <location filename="../application.cpp" line="1650"/>
+        <source>I rearranged some database files and need to restart myself, see you in a bit!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1619"/>
+        <source>Copying the database to %1 failed! Check write permissions.
+Keeping Portable Mode enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="1635"/>
+        <source>Copying the statistics file to %1 failed! Check write permissions.
+Keeping Portable Mode enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="2024"/>
+        <location filename="../application.cpp" line="2037"/>
+        <source>Premium features disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="2025"/>
+        <source>I was not able to contact the website to verify your premium membership for 96 hours. I have disabled the premium features. Go back online to enable again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../application.cpp" line="2038"/>
+        <source>Your premium membership has expired so I have disabled the premium features. You can reactivate your membership via the website.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BugReportWindow</name>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="65"/>
+        <source>Report a Bug</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BugReportWindowTab</name>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="98"/>
+        <source>Send Report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="107"/>
+        <source>Page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="111"/>
+        <source>Send Database?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="117"/>
+        <source>Description:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="135"/>
+        <source>Send Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="136"/>
+        <source>When you select &apos;Send Database&apos; - a copy of your local database will be sent to the WhatPulse developers so they can more easily reproduce issues.&lt;br /&gt;&lt;br /&gt;Your database is: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="145"/>
+        <source>No Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="146"/>
+        <source>Please enter a description of the issue you are running into.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="196"/>
+        <source>Thanks!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="197"/>
+        <source>Bug Report successfully sent, thanks for reporting!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="203"/>
+        <source>Uh oh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="204"/>
+        <source>Something went wrong while reporting your bug. Please try again!&lt;br /&gt;&lt;br /&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/BugReportWindow.cpp" line="218"/>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ClientCommunication</name>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="230"/>
+        <source>The website is not responding correctly to your request, please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="258"/>
+        <source>Your account is pending activation, please check your email and try again after activating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="262"/>
+        <location filename="../online/clientcommunication.cpp" line="318"/>
+        <source>Account or computer unknown! Did you register?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="265"/>
+        <location filename="../online/clientcommunication.cpp" line="321"/>
+        <source>Wrong password! Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="269"/>
+        <location filename="../online/clientcommunication.cpp" line="345"/>
+        <source>Server is down due to maintenance, please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="272"/>
+        <location filename="../online/clientcommunication.cpp" line="348"/>
+        <source>Internal server error. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="276"/>
+        <location filename="../online/clientcommunication.cpp" line="352"/>
+        <source>Server error: Missing input! Please contact the developers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="324"/>
+        <source>Activity throttled breached, this means your keys or clicks per second is too high. Wait an hour or so to lower it and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="330"/>
+        <source>Wrong token, did you use this profile on another computer?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="333"/>
+        <source>Requested username is already registered! Please choose another username and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="338"/>
+        <source>Pulse throttled. You can only pulse every 60 seconds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="341"/>
+        <source>Premium only feature.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="355"/>
+        <location filename="../online/clientcommunication.cpp" line="874"/>
+        <source>Success.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="358"/>
+        <source>Success, your file is now on the website!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="863"/>
+        <source>Unable to open GeoIP database (%1), permission denied.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="925"/>
+        <source>Empty reply received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="947"/>
+        <source>Unable to open Network Port Description database (%1), permission denied.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/clientcommunication.cpp" line="961"/>
+        <source>Downloaded file does not look good: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Database</name>
+    <message>
+        <location filename="../util/database.cpp" line="54"/>
+        <location filename="../util/database.cpp" line="66"/>
+        <source>Database failure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../util/database.cpp" line="55"/>
+        <source>Unable to setup database: %1
+
+Please check your permissions on: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../util/database.cpp" line="67"/>
+        <source>Unable to setup database: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../util/database.cpp" line="152"/>
+        <source>The database &apos;%1&apos; is read-only. WhatPulse cannot store any statistics until you fix this problem.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../util/database.cpp" line="196"/>
+        <location filename="../util/database.cpp" line="228"/>
+        <source>Critical database error!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../util/database.cpp" line="197"/>
+        <location filename="../util/database.cpp" line="229"/>
+        <source>Something really bad happened to the database and the backup database. The only way to recover is to create a new database. This will not effect your unpulsed stats, but will wipe the rest. Continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../util/database.cpp" line="347"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../util/database.cpp" line="348"/>
+        <source>It is not supported to downgrade the WhatPulse client, please install the latest version and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DatabaseBackupWindow</name>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="42"/>
+        <source>WhatPulse Database Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="55"/>
+        <source>Hi there! According to my records, it&apos;s been &lt;b&gt;%1&lt;/b&gt; days since your last online database backup. Please take a minute and do so now. This window will close automatically when I&apos;m done.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="67"/>
+        <source>Your database is &lt;b&gt;%1&lt;/b&gt;, which should take around &lt;b&gt;%2&lt;/b&gt; to upload.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="89"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="96"/>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="112"/>
+        <source>Start Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="126"/>
+        <source>Checking with website..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="161"/>
+        <source>Premium only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="162"/>
+        <source>Sorry, the online backup feature is for Premium members only. There&apos;s more information here: https://whatpulse.org/premium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="171"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="172"/>
+        <source>Sorry, the website gave an error preparing for your backup. Please try again later. Here&apos;s the error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="184"/>
+        <source>Zipping database..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="205"/>
+        <source>Starting upload..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/DatabaseBackupWindow.cpp" line="223"/>
+        <source>All done!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExportWindow</name>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="22"/>
+        <source>WhatPulse Export Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FactsWindow</name>
+    <message>
+        <location filename="../interface/FactsWindow.cpp" line="15"/>
+        <location filename="../interface/FactsWindow.cpp" line="53"/>
+        <source>Facts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/FactsWindow.cpp" line="94"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FvUpdateConfirmDialog</name>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="14"/>
+        <source>Software Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="20"/>
+        <source>The update file is located at:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="27"/>
+        <source>&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="40"/>
+        <source>Download this update, close &quot;%1&quot;, install it, and then reopen &quot;%1&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="47"/>
+        <source>When you click &quot;OK&quot;, this link will be opened in your browser.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FvUpdateDownloadProgress</name>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatedownloadprogress.ui" line="23"/>
+        <source>FvUpdateDownloadProgress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatedownloadprogress.ui" line="70"/>
+        <source>Downloading Update...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatedownloadprogress.ui" line="98"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FvUpdateWindow</name>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="26"/>
+        <source>Software Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="43"/>
+        <source>A new version of %1 is available!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="50"/>
+        <source>%1 %2 is now available - you have %3. Would you like to download it now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="63"/>
+        <source>Release Notes:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="77"/>
+        <source>Skip This Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="97"/>
+        <source>Remind Me Later</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="104"/>
+        <source>Install Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FvUpdater</name>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="310"/>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="429"/>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="457"/>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="466"/>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="470"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="310"/>
+        <source>Feed download failed: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="429"/>
+        <source>Feed parsing failed: %1 %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="457"/>
+        <source>Feed error: &quot;release notes&quot; link is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="466"/>
+        <source>Feed error: invalid &quot;release notes&quot; link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="470"/>
+        <source>Feed error: invalid &quot;enclosure&quot; with the download link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="477"/>
+        <source>Updater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="477"/>
+        <source>&lt;b&gt;You&apos;re up to date!&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;whatpulse %1 is currently the newest version available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="560"/>
+        <source>SSL fingerprint check: The url %1 is not a ssl connection!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="653"/>
+        <source>Unable to open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="653"/>
+        <source>Unable to open this link in a browser. Please try manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InputPage</name>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="144"/>
+        <source>Exporting Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="145"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="151"/>
+        <source>Please make your exporting selection below. Select what data you want, then the timespan and whether you want to group it per day, week or month and press Save to export as CSV.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="158"/>
+        <source>History of Keys and Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="159"/>
+        <source>Heatmap of Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="160"/>
+        <source>Heatmap of Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="161"/>
+        <source>Application Keys and Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="173"/>
+        <source>Export from:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="183"/>
+        <source>to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="202"/>
+        <source>Group by:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="204"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="205"/>
+        <source>Day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="206"/>
+        <source>Week</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="207"/>
+        <source>Month</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="217"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="225"/>
+        <source>Premium Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="234"/>
+        <source>Working..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="279"/>
+        <source>History of keys and clicks between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="297"/>
+        <location filename="../interface/ExportWindow.cpp" line="385"/>
+        <location filename="../interface/ExportWindow.cpp" line="454"/>
+        <location filename="../interface/ExportWindow.cpp" line="504"/>
+        <source>grouped by Week </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="308"/>
+        <location filename="../interface/ExportWindow.cpp" line="392"/>
+        <location filename="../interface/ExportWindow.cpp" line="512"/>
+        <source>grouped by Month </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="321"/>
+        <location filename="../interface/ExportWindow.cpp" line="401"/>
+        <location filename="../interface/ExportWindow.cpp" line="522"/>
+        <source>grouped by Hour </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="332"/>
+        <location filename="../interface/ExportWindow.cpp" line="408"/>
+        <location filename="../interface/ExportWindow.cpp" line="467"/>
+        <location filename="../interface/ExportWindow.cpp" line="530"/>
+        <source>grouped by Day </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="374"/>
+        <source>Heatmap of keys between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="436"/>
+        <source>Heatmap of clicks between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="443"/>
+        <source>Unsupported Grouping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="444"/>
+        <source>Unfortunately, per hour grouping on the mouse heat map is not supported. I&apos;ve changed the grouping to per day.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="492"/>
+        <source>Application input between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="577"/>
+        <source>You have selected a date range larger than 90 days. Exporting may take a while.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InputTab</name>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="71"/>
+        <location filename="../interface/InputTab.cpp" line="73"/>
+        <location filename="../interface/InputTab.cpp" line="75"/>
+        <location filename="../interface/InputTab.cpp" line="77"/>
+        <location filename="../interface/InputTab.cpp" line="1141"/>
+        <location filename="../interface/InputTab.cpp" line="1151"/>
+        <location filename="../interface/InputTab.cpp" line="1161"/>
+        <source>Keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="72"/>
+        <location filename="../interface/InputTab.cpp" line="74"/>
+        <location filename="../interface/InputTab.cpp" line="76"/>
+        <location filename="../interface/InputTab.cpp" line="78"/>
+        <location filename="../interface/InputTab.cpp" line="1142"/>
+        <location filename="../interface/InputTab.cpp" line="1152"/>
+        <location filename="../interface/InputTab.cpp" line="1162"/>
+        <source>Clicks:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="99"/>
+        <source>Keyboard Heatmap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="100"/>
+        <source>Mouse Heatmap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="101"/>
+        <source>Applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="102"/>
+        <source>Input History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="104"/>
+        <source>Key Combinations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="125"/>
+        <source> Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="191"/>
+        <source>Combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="191"/>
+        <source>Used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="208"/>
+        <source>Hide Shift only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="217"/>
+        <source>Hide Ctrl only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="286"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="286"/>
+        <location filename="../interface/InputTab.cpp" line="1069"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="287"/>
+        <location filename="../interface/InputTab.cpp" line="508"/>
+        <location filename="../interface/InputTab.cpp" line="1069"/>
+        <source>Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="297"/>
+        <source>Go Premium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="306"/>
+        <location filename="../interface/InputTab.cpp" line="431"/>
+        <location filename="../interface/InputTab.cpp" line="724"/>
+        <location filename="../interface/InputTab.cpp" line="1099"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="319"/>
+        <location filename="../interface/InputTab.cpp" line="443"/>
+        <location filename="../interface/InputTab.cpp" line="736"/>
+        <location filename="../interface/InputTab.cpp" line="1111"/>
+        <source>&amp;Export to .csv</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="323"/>
+        <location filename="../interface/InputTab.cpp" line="446"/>
+        <location filename="../interface/InputTab.cpp" line="740"/>
+        <source>&amp;Export to .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="328"/>
+        <location filename="../interface/InputTab.cpp" line="450"/>
+        <location filename="../interface/InputTab.cpp" line="744"/>
+        <location filename="../interface/InputTab.cpp" line="1115"/>
+        <source>&amp;Export Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="348"/>
+        <source>Last 12 hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="349"/>
+        <source>Last 24 hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="350"/>
+        <source>Last 7 days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="351"/>
+        <source>Last 7 weeks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="352"/>
+        <source>Last 7 months</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="355"/>
+        <source>Group by Hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="356"/>
+        <source>Group by Days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="357"/>
+        <source>Group by Weeks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="359"/>
+        <source>Group by Months</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="360"/>
+        <source>Group by Years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="407"/>
+        <location filename="../interface/InputTab.cpp" line="711"/>
+        <source>Enable Heatmap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="417"/>
+        <source>Prune older than 3 months</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="459"/>
+        <location filename="../interface/InputTab.cpp" line="752"/>
+        <source>Share</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="502"/>
+        <source>&lt;b&gt;Buttons Usage&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="508"/>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="537"/>
+        <source>Mouse heat map selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="541"/>
+        <source>Switch to button view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="548"/>
+        <source>Switch to mouse heat map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="553"/>
+        <source>Button view selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="637"/>
+        <source>Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="637"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="679"/>
+        <source>Layout:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="770"/>
+        <source>Application:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="777"/>
+        <source>Per-App Stats Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="777"/>
+        <location filename="../interface/InputTab.cpp" line="780"/>
+        <location filename="../interface/InputTab.cpp" line="783"/>
+        <location filename="../interface/InputTab.cpp" line="1850"/>
+        <location filename="../interface/InputTab.cpp" line="1851"/>
+        <location filename="../interface/InputTab.cpp" line="1880"/>
+        <location filename="../interface/InputTab.cpp" line="1881"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="780"/>
+        <location filename="../interface/InputTab.cpp" line="1850"/>
+        <location filename="../interface/InputTab.cpp" line="1851"/>
+        <location filename="../interface/InputTab.cpp" line="1880"/>
+        <location filename="../interface/InputTab.cpp" line="1881"/>
+        <source>Premium Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="841"/>
+        <location filename="../interface/InputTab.cpp" line="1140"/>
+        <source>&lt;b&gt;Today&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="853"/>
+        <location filename="../interface/InputTab.cpp" line="1150"/>
+        <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="865"/>
+        <source>&lt;b&gt;Unpulsed&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="877"/>
+        <location filename="../interface/InputTab.cpp" line="1160"/>
+        <source>&lt;b&gt;All time&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="936"/>
+        <source>Keyboard heat map selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="940"/>
+        <location filename="../interface/InputTab.cpp" line="1009"/>
+        <source>Switch to table view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="948"/>
+        <source>Switch to keyboard heat map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="953"/>
+        <location filename="../interface/InputTab.cpp" line="1021"/>
+        <source>Table view selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="1005"/>
+        <source>Chart view selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="1016"/>
+        <source>Switch to chart view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="1069"/>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="1132"/>
+        <location filename="../interface/InputTab.cpp" line="1986"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="1135"/>
+        <location filename="../interface/InputTab.cpp" line="1136"/>
+        <location filename="../interface/InputTab.cpp" line="1145"/>
+        <location filename="../interface/InputTab.cpp" line="1146"/>
+        <location filename="../interface/InputTab.cpp" line="1155"/>
+        <location filename="../interface/InputTab.cpp" line="1156"/>
+        <location filename="../interface/InputTab.cpp" line="2864"/>
+        <location filename="../interface/InputTab.cpp" line="2865"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="1904"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="1965"/>
+        <source>&lt;b&gt;You have disabled per application input statistics in the Settings.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="1993"/>
+        <source>Summary of </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2093"/>
+        <source>Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2093"/>
+        <source>Middle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2093"/>
+        <source>Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2093"/>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2469"/>
+        <source>keyboard historical data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2474"/>
+        <source>mouse historical data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2475"/>
+        <source>Reset Mouse History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2479"/>
+        <source>application historical data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2480"/>
+        <source>Reset Application History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2484"/>
+        <source>keyboard and mouse historical data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2485"/>
+        <source>Reset Keyboard and Mouse History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2489"/>
+        <source>key combination historical data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2490"/>
+        <source>Reset Key Combinations History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2494"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2496"/>
+        <source>Do you want to reset all input data or just the </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2499"/>
+        <source>Reset All Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2514"/>
+        <location filename="../interface/InputTab.cpp" line="2534"/>
+        <location filename="../interface/InputTab.cpp" line="2555"/>
+        <location filename="../interface/InputTab.cpp" line="2568"/>
+        <location filename="../interface/InputTab.cpp" line="2592"/>
+        <location filename="../interface/InputTab.cpp" line="2608"/>
+        <source>Delete stats?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2515"/>
+        <source>Are you sure you want to delete all recorded keyboard statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2535"/>
+        <source>Are you sure you want to delete all recorded mouse statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2556"/>
+        <source>Are you sure you want to delete all recorded per application input statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2569"/>
+        <source>Are you sure you want to delete all recorded keyboard and mouse statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2593"/>
+        <source>Are you sure you want to delete all recorded key combination statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2609"/>
+        <source>Are you sure you want to delete all recorded input statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2638"/>
+        <source>No input devices found, are your &lt;a href=&quot;http://whatpulse.org/kb/content/7/15/en/linux-installation.html&quot;&gt;permissions&lt;/a&gt; set up correctly?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2719"/>
+        <source>Ignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2725"/>
+        <source>Open File Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2731"/>
+        <source>Open Online Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2746"/>
+        <source>Ignore application?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2747"/>
+        <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2800"/>
+        <source>Not yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2801"/>
+        <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2824"/>
+        <source>Prune Mouse Heatmap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/InputTab.cpp" line="2825"/>
+        <source>By not pruning your mouse heatmap, your database will get pretty large and possibly slow WhatPulse down. Stop pruning?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>IntroPage</name>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="62"/>
+        <source>Export Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="68"/>
+        <source>Welcome to the Export Wizard. This wizard allows you to export all your data inside the WhatPulse client into a CSV file. Pick a statistic and press Next!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="75"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="76"/>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="77"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="93"/>
+        <source>This advanced export wizard is a &lt;b&gt;premium only&lt;/b&gt; feature. You can browse to see the possibilities, but you need a premium subscription to export data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="105"/>
+        <source>Go Premium</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardHeatmap</name>
+    <message>
+        <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="421"/>
+        <source>Image not created!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="422"/>
+        <source>Unable to generate heatmap image. Please try again or check permissions on: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="460"/>
+        <source>Pressed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="515"/>
+        <source>Image posted online!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="516"/>
+        <source>Keyboard image succesfully uploaded! Do you want to view it in your browser?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="528"/>
+        <source>Error uploading file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LocalStats</name>
+    <message>
+        <location filename="../stats/localstats.cpp" line="231"/>
+        <source>Pulse throttled!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../stats/localstats.cpp" line="232"/>
+        <source>Pulse throttled! Your last pulse was %1 seconds ago, please try again in 10 seconds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../stats/localstats.cpp" line="308"/>
+        <source>Error while pulsing!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../interface/MainWindow.cpp" line="196"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/MainWindow.cpp" line="197"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/MainWindow.cpp" line="198"/>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/MainWindow.cpp" line="199"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/MainWindow.cpp" line="200"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/MainWindow.cpp" line="203"/>
+        <location filename="../interface/MainWindow.cpp" line="256"/>
+        <location filename="../interface/MainWindow.cpp" line="303"/>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MouseButtons</name>
+    <message>
+        <location filename="../interface/widgets/MouseButtons.cpp" line="27"/>
+        <source>Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/MouseButtons.cpp" line="30"/>
+        <source>Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/MouseButtons.cpp" line="33"/>
+        <source>Middle</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MouseHeatmap</name>
+    <message>
+        <location filename="../interface/widgets/MouseHeatmap.cpp" line="98"/>
+        <source>Image not created!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/MouseHeatmap.cpp" line="99"/>
+        <source>Unable to generate heatmap image. Please try again or check permissions on: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/MouseHeatmap.cpp" line="281"/>
+        <source>Image posted online!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/MouseHeatmap.cpp" line="282"/>
+        <source>Mouse heatmap succesfully uploaded! Do you want to view it in your browser?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/MouseHeatmap.cpp" line="294"/>
+        <source>Error uploading file!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkInterfaces_WiredvsWirelessButtons</name>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="561"/>
+        <source>Show Wired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="563"/>
+        <source>Hide Wired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="572"/>
+        <source>Show Wifi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="574"/>
+        <source>Hide Wifi</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkPage</name>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="587"/>
+        <source>Exporting Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="588"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="594"/>
+        <source>Please make your exporting selection below. Select what data you want, then the timespan and whether you want to group it per day, week or month and press Save to export as CSV.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="601"/>
+        <source>Traffic per application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="602"/>
+        <source>Traffic per country</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="603"/>
+        <source>Traffic per network interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="604"/>
+        <source>Traffic per type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="616"/>
+        <source>Export from:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="626"/>
+        <source>to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="645"/>
+        <source>Group by:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="647"/>
+        <source>Day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="648"/>
+        <location filename="../interface/ExportWindow.cpp" line="742"/>
+        <location filename="../interface/ExportWindow.cpp" line="806"/>
+        <location filename="../interface/ExportWindow.cpp" line="865"/>
+        <location filename="../interface/ExportWindow.cpp" line="928"/>
+        <source>Week</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="649"/>
+        <location filename="../interface/ExportWindow.cpp" line="750"/>
+        <location filename="../interface/ExportWindow.cpp" line="813"/>
+        <location filename="../interface/ExportWindow.cpp" line="873"/>
+        <location filename="../interface/ExportWindow.cpp" line="937"/>
+        <source>Month</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="659"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="667"/>
+        <source>Premium Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="676"/>
+        <source>Working..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="719"/>
+        <source>Network interface traffic between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="749"/>
+        <location filename="../interface/ExportWindow.cpp" line="812"/>
+        <location filename="../interface/ExportWindow.cpp" line="872"/>
+        <location filename="../interface/ExportWindow.cpp" line="936"/>
+        <source>grouped by Week </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="757"/>
+        <location filename="../interface/ExportWindow.cpp" line="819"/>
+        <location filename="../interface/ExportWindow.cpp" line="880"/>
+        <location filename="../interface/ExportWindow.cpp" line="945"/>
+        <source>grouped by Month </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="765"/>
+        <location filename="../interface/ExportWindow.cpp" line="827"/>
+        <location filename="../interface/ExportWindow.cpp" line="888"/>
+        <location filename="../interface/ExportWindow.cpp" line="954"/>
+        <source>grouped by Day </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="784"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="801"/>
+        <source>Network per applications between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="860"/>
+        <source>Country network traffic between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="923"/>
+        <source>Network per type between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1008"/>
+        <source>You have selected a date range larger than 90 days. Exporting may take a while.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkTab</name>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="46"/>
+        <source>Interfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="47"/>
+        <source>Applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="48"/>
+        <source>Realtime Bandwidth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="49"/>
+        <source>Bandwidth per Country</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="50"/>
+        <source>Traffic Types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="69"/>
+        <source> Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="144"/>
+        <source>Your GeoIP database is empty, per country stats won&apos;t work. Click &lt;a href=&quot;#&quot;&gt;here&lt;/a&gt; to refresh the database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="178"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="180"/>
+        <source>Yes, with IP </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="183"/>
+        <source>Testing..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="185"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="201"/>
+        <source>interface historical data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="202"/>
+        <source>Reset Interface History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="206"/>
+        <source>per application history data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="207"/>
+        <source>Reset Application History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="211"/>
+        <source>per country history data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="212"/>
+        <source>Reset Country History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="216"/>
+        <source>per traffic type data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="217"/>
+        <source>Reset Traffic Types History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="221"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="223"/>
+        <source>Do you want to reset all network data or just the %1?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="226"/>
+        <source>Reset All Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="241"/>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="256"/>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="270"/>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="283"/>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="299"/>
+        <source>Delete stats?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="242"/>
+        <source>Are you sure you want to delete all recorded network interface statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="257"/>
+        <source>Are you sure you want to delete all recorded per application network statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="271"/>
+        <source>Are you sure you want to delete all recorded per country network statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="284"/>
+        <source>Are you sure you want to delete all recorded per traffic type network statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="300"/>
+        <source>Are you sure you want to delete all recorded network statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="368"/>
+        <source>Success!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="368"/>
+        <source>GeoIP Database updated succesfully!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="371"/>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="376"/>
+        <source>Something went wrong!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="372"/>
+        <source>GeoIP Database did not update succesfully, unknown error. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="377"/>
+        <source>GeoIP Database did not update succesfully, here&apos;s the error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="386"/>
+        <source>Npcap not found, which is needed for network statistics.&lt;br&gt;Download at &lt;a href=&quot;https://nmap.org/npcap/&quot;&gt;nmap.org&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="390"/>
+        <source>LibPcap not found, which is needed for network statistics.&lt;br&gt;Please install package.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkTabApplications</name>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="19"/>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="20"/>
+        <source>Current download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="21"/>
+        <source>Current upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="43"/>
+        <source>Show only active applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="52"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="64"/>
+        <source>&amp;Export Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="74"/>
+        <source>Go Premium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="106"/>
+        <source>Testing..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="110"/>
+        <source>Internet:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="116"/>
+        <source>Show in bytes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="117"/>
+        <source>Show in bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="136"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="191"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="139"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="140"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="149"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="150"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="159"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="160"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="539"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="540"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="144"/>
+        <source>&lt;b&gt;Today&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="145"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="155"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="165"/>
+        <source>Downloaded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="146"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="156"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="166"/>
+        <source>Uploaded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="154"/>
+        <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="164"/>
+        <source>&lt;b&gt;All time&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="255"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="341"/>
+        <source>Summary of </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="388"/>
+        <source>(Per-application bandwidth is disabled)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="394"/>
+        <source>Total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="405"/>
+        <source>Ignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="411"/>
+        <source>Open File Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="417"/>
+        <source>Open Online Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="432"/>
+        <source>Ignore application?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="433"/>
+        <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="485"/>
+        <source>Not yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="486"/>
+        <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkTabCountry</name>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="47"/>
+        <source>Country</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="47"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="48"/>
+        <source>Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="64"/>
+        <source>Go Premium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="82"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="94"/>
+        <source>&amp;Export to .csv</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="97"/>
+        <source>&amp;Export to .png</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="101"/>
+        <source>&amp;Export Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="208"/>
+        <source>Network heat map selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="212"/>
+        <source>Switch to table view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="220"/>
+        <source>Switch to network heat map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="225"/>
+        <source>Table view selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkTabGraph</name>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="143"/>
+        <source>Testing..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="147"/>
+        <source>Internet:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="151"/>
+        <source>Show:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="153"/>
+        <source>5 mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="154"/>
+        <source>15 mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="155"/>
+        <source>30 mins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="156"/>
+        <source>1 hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="165"/>
+        <source>in bytes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="166"/>
+        <source>in bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="186"/>
+        <source>Summary of real-time bandwidth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="189"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="190"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="199"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="200"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="209"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="210"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="194"/>
+        <source>&lt;b&gt;Current&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="195"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="205"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="215"/>
+        <source>Download:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="196"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="206"/>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="216"/>
+        <source>Upload:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="204"/>
+        <source>&lt;b&gt;Average&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="214"/>
+        <source>&lt;b&gt;Maximum&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkTabInterfaces</name>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="26"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="479"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="487"/>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="26"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="479"/>
+        <source>Current download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="27"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="480"/>
+        <source>Current upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="27"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="480"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="488"/>
+        <source>IP-address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="37"/>
+        <source>Total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="60"/>
+        <source>Show only active interfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="69"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="81"/>
+        <source>&amp;Export Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="106"/>
+        <source>Testing..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="111"/>
+        <source>Internet:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="123"/>
+        <source>Show in bytes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="124"/>
+        <source>Show in bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="142"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="205"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="145"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="146"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="155"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="156"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="165"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="166"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="373"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="374"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="150"/>
+        <source>&lt;b&gt;Today&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="151"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="161"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="171"/>
+        <source>Downloaded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="152"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="162"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="172"/>
+        <source>Uploaded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="160"/>
+        <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="170"/>
+        <source>&lt;b&gt;All time&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="201"/>
+        <source>Summary of Wireless Bandwidth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="203"/>
+        <source>Summary of Wired Bandwidth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="440"/>
+        <source>Ignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="487"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="488"/>
+        <source>Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkTypeTraffic</name>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="24"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="24"/>
+        <source>Protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="25"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="25"/>
+        <source>Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="43"/>
+        <source>Record unknown traffic types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="56"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="68"/>
+        <source>&amp;Export Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="77"/>
+        <source>Go Premium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="102"/>
+        <source>Record Unknown Traffic Types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="103"/>
+        <source>By recording unknown traffic types, your database will get pretty large and possibly slow WhatPulse down. Still record unknown?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="116"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="119"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="120"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="129"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="130"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="139"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="140"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="329"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="330"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="124"/>
+        <source>&lt;b&gt;Today&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="125"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="135"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="145"/>
+        <source>Downloaded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="126"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="136"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="146"/>
+        <source>Uploaded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="134"/>
+        <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="144"/>
+        <source>&lt;b&gt;All time&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="169"/>
+        <source>All Traffic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="225"/>
+        <source>Summary of </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="268"/>
+        <source>(Per-type bandwidth is disabled)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OverviewTab</name>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="38"/>
+        <source>&lt;b&gt;Note:&lt;/b&gt; Apple M1 is not fully supported. &lt;a href=&quot;https://help.whatpulse.org/kb/client/whatpulse-support-for-apple-m1&quot;&gt;More info here&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="56"/>
+        <source>&lt;b&gt;Note:&lt;/b&gt; According to my records, it&apos;s been &lt;b&gt;%1&lt;/b&gt; days since your last online database backup. Please take a minute &lt;a href=&quot;#&quot;&gt;and do so now&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="76"/>
+        <source>Open Window on Startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="83"/>
+        <source> Pulse!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="103"/>
+        <source>Start Online Backup?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="104"/>
+        <source>Starting a backup will restart the client and show the backup window. Continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="154"/>
+        <source>Current uptime: unknown. Unknown reboots.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="160"/>
+        <source>Total keycount: unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="166"/>
+        <source>Total clickcount: unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="172"/>
+        <location filename="../interface/OverviewTab.cpp" line="314"/>
+        <source>Down: unknown
+Up: unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="192"/>
+        <location filename="../interface/OverviewTab.cpp" line="237"/>
+        <source>Total: %1
+Available: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="260"/>
+        <source>Total clickcount: %1
+Unpulsed: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="273"/>
+        <source>Total keycount: %1
+Unpulsed: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="280"/>
+        <location filename="../interface/OverviewTab.cpp" line="281"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="298"/>
+        <source>Current uptime: %1. %2 reboots
+Unpulsed: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="310"/>
+        <source>Down: %1
+Up: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="318"/>
+        <source>%1
+Unpulsed: %2 down, %3 up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="328"/>
+        <source>The option &apos;Work Offline&apos; is enabled, so you cannot pulse. Disable that option to resume pulsing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="339"/>
+        <source>Pulsing Disabled!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="340"/>
+        <source>The setting &quot;Work Offline&quot; is enabled. This prevents the client from going online, which includes pulsing. Disable that setting and you can pulse again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="349"/>
+        <source>Pulsing..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="350"/>
+        <source>Pulse underway, please wait!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/OverviewTab.cpp" line="355"/>
+        <source>Pulse!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PermissionsManager</name>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="55"/>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="245"/>
+        <source>Restart WhatPulse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="58"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="64"/>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="228"/>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="247"/>
+        <source>Quit WhatPulse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="100"/>
+        <source>&lt;h1&gt;Setup Permissions&lt;/h1&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="104"/>
+        <source>WhatPulse needs some macOS permissions to count your stats. &lt;br /&gt;Follow the steps below to make sure WhatPulse will work correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="124"/>
+        <source>&lt;h2&gt;Accessibility&lt;/h2&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="128"/>
+        <source>WhatPulse needs Accessibility permissions to discover applications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="142"/>
+        <source>Open Accessibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="169"/>
+        <source>&lt;h2&gt;Input Monitoring&lt;/h2&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="174"/>
+        <source>WhatPulse needs permissions to count your keys and clicks.  Don&apos;t quit WhatPulse when asked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="188"/>
+        <source>Open Input Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="211"/>
+        <source>&lt;center&gt;Here&apos;s how it should look: &lt;br /&gt;&lt;br /&gt;&lt;img src=&quot;:/mac/preferences_example.png&quot; /&gt;&lt;br /&gt;&lt;br /&gt;If the checkbox is already checked,  try unchecking and checking it again.  This can be needed after upgrades.&lt;/center&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/mac/permissionsmanager.cpp" line="217"/>
+        <source>&lt;center&gt;All set! WhatPulse has the right permissions.&lt;/center&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ProgressWindow</name>
+    <message>
+        <location filename="../resources/progresswindow.ui" line="23"/>
+        <source>ProgressWindow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../resources/progresswindow.ui" line="70"/>
+        <source>Downloading Update...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../resources/progresswindow.ui" line="98"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/progresswindow.cpp" line="24"/>
+        <source>Success!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../system/mac/macnativehelpers.mm" line="364"/>
+        <source>Accessibility Permissions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../system/mac/macnativehelpers.mm" line="365"/>
+        <source>Please allow the client the Accessibility Permission, to allow keyboard &amp; mouse monitoring. Then press OK and WhatPulse will restart. Cancel to exit the client.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../system/mac/macnativehelpers.mm" line="425"/>
+        <source>Access for assistive devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../system/mac/macnativehelpers.mm" line="426"/>
+        <source>Mac OS Version not supported; Please tick &quot;Enable access for assistive devices&quot; in the Universal Access pane in System Preferences and restart the client. Keycounting will not work otherwise. An upgraded client requires a re-enable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaGzipFile</name>
+    <message>
+        <location filename="../3rdparty/quazip/quagzipfile.cpp" line="60"/>
+        <source>QIODevice::Append is not supported for GZIP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/quazip/quagzipfile.cpp" line="66"/>
+        <source>Opening gzip for both reading and writing is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/quazip/quagzipfile.cpp" line="74"/>
+        <source>You can open a gzip either for reading or for writing. Which is it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/quazip/quagzipfile.cpp" line="80"/>
+        <source>Could not gzopen() file</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaZIODevice</name>
+    <message>
+        <location filename="../3rdparty/quazip/quaziodevice.cpp" line="188"/>
+        <source>QIODevice::Append is not supported for QuaZIODevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../3rdparty/quazip/quaziodevice.cpp" line="193"/>
+        <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaZipFile</name>
+    <message>
+        <location filename="../3rdparty/quazip/quazipfile.cpp" line="251"/>
+        <source>ZIP/UNZIP API error %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTab</name>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="113"/>
+        <source>General Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="114"/>
+        <source>Automatic Pulsing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="115"/>
+        <source>Geek Window Layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="117"/>
+        <source>Ignored Applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="119"/>
+        <source>Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="120"/>
+        <source>Milestones</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="126"/>
+        <source> Check for Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="138"/>
+        <source> Report Bug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="153"/>
+        <source> Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="186"/>
+        <location filename="../interface/SettingsTab.cpp" line="202"/>
+        <source>Settings - General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="188"/>
+        <location filename="../interface/SettingsTab.cpp" line="203"/>
+        <source>Settings - Automatic Pulsing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="190"/>
+        <location filename="../interface/SettingsTab.cpp" line="204"/>
+        <source>Settings - Geek Window Layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="192"/>
+        <location filename="../interface/SettingsTab.cpp" line="205"/>
+        <source>Settings - Ignored Applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="194"/>
+        <location filename="../interface/SettingsTab.cpp" line="206"/>
+        <source>Settings - Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="196"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="266"/>
+        <source>Launch when computer starts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="268"/>
+        <source>Enable Portable Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="270"/>
+        <source>Pulse on doubleclick trayicon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="274"/>
+        <source>Include beta versions updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="278"/>
+        <source>Blink trayicon on input activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="281"/>
+        <source>Automatically install new versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="283"/>
+        <source>Upload application info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="286"/>
+        <source>Work offline (disables pulsing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="289"/>
+        <source>Upload heatmap info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="292"/>
+        <source>Weekly online backups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="327"/>
+        <source>Icon color: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="331"/>
+        <location filename="../interface/SettingsTab.cpp" line="820"/>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="331"/>
+        <location filename="../interface/SettingsTab.cpp" line="822"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="331"/>
+        <location filename="../interface/SettingsTab.cpp" line="824"/>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="333"/>
+        <location filename="../interface/SettingsTab.cpp" line="827"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="348"/>
+        <source>Language: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="374"/>
+        <source>Pulse Server: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="390"/>
+        <source>Active Stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="400"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="406"/>
+        <source>Keyboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="407"/>
+        <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="408"/>
+        <location filename="../interface/SettingsTab.cpp" line="428"/>
+        <location filename="../interface/SettingsTab.cpp" line="449"/>
+        <source>Per Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="418"/>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="424"/>
+        <source>Per Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="426"/>
+        <source>Per Country</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="430"/>
+        <source>Per Traffic Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="440"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="446"/>
+        <source>Computer Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="447"/>
+        <source>Reboots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="467"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="473"/>
+        <source>&amp;Open Data Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="480"/>
+        <source>&amp;Start Online Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="487"/>
+        <source>Re-upload &amp;applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="493"/>
+        <source>Empty local &amp;database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="499"/>
+        <source>Update &amp;GeoIP database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="506"/>
+        <source>Update Network Port Description database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="513"/>
+        <source>&amp;Upload database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="525"/>
+        <source>Check macOS Permissions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="549"/>
+        <source>Uploading applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="576"/>
+        <source>Uploading Apps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="577"/>
+        <source>Applications have been marked for upload. It might take an hour before they appear on the website.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="594"/>
+        <source>Empty Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="595"/>
+        <source>Emptying out your local database will destroy all local statistics and logout your account. There is no recovery for this, continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="614"/>
+        <source>Start Online Backup?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="615"/>
+        <source>Starting a backup will restart the client and show the backup window. Continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="773"/>
+        <source>Settings saved...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab.cpp" line="812"/>
+        <source>Weekly online backups (premium only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTabAutoPulse</name>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="9"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="10"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="11"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="12"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="13"/>
+        <source>Auto pulse on </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="14"/>
+        <source>Auto pulse on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="80"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="87"/>
+        <source>Enter a value between 1000 and 99999999</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="94"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="101"/>
+        <source>Enter a value between 1024 and 99999999</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="108"/>
+        <source>Enter a value between 1 and 9999</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="131"/>
+        <source>keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="136"/>
+        <source>clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="141"/>
+        <source>MB downloaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="146"/>
+        <source>MB uploaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="151"/>
+        <source>hours uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="168"/>
+        <source>Auto pulse on hour </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="172"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="456"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="179"/>
+        <source>every day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="180"/>
+        <source>every Monday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="181"/>
+        <source>every Tuesday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="182"/>
+        <source>every Wednesday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="183"/>
+        <source>every Thursday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="184"/>
+        <source>every Friday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="185"/>
+        <source>every Saturday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="186"/>
+        <source>every Sunday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="371"/>
+        <source>WhatPulse will not automatically pulse with your current settings. Change a setting to enable auto pulsing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="374"/>
+        <source>WhatPulse will automatically pulse </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="386"/>
+        <source>when </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="392"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="403"/>
+        <source>you reach </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="395"/>
+        <source> keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="401"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="413"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="424"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="435"/>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="446"/>
+        <source>, &lt;b&gt;or&lt;/b&gt; when </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="406"/>
+        <source> clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="415"/>
+        <source>you&apos;ve downloaded </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="426"/>
+        <source>you&apos;ve uploaded </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="437"/>
+        <source>you&apos;ve collected </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="440"/>
+        <source> hours of uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="448"/>
+        <source>the client starts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="454"/>
+        <source>, &lt;b&gt;and&lt;/b&gt; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="457"/>
+        <source>every hour on </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTabGeekWindow</name>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="72"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="91"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="343"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="512"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="525"/>
+        <source>Select label to edit..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="108"/>
+        <source>Delete label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="123"/>
+        <source>Insert statistic:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="124"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="429"/>
+        <source>Unpulsed Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="125"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="431"/>
+        <source>Unpulsed Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="126"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="433"/>
+        <source>Unpulsed Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="127"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="435"/>
+        <source>Unpulsed Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="128"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="437"/>
+        <source>Unpulsed Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="129"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="439"/>
+        <source>Unpulsed Click Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="130"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="441"/>
+        <source>Unpulsed Key Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="131"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="443"/>
+        <source>Unpulsed Download Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="132"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="445"/>
+        <source>Unpulsed Upload Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="133"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="447"/>
+        <source>Current Click Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="134"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="449"/>
+        <source>Current Key Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="135"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="451"/>
+        <source>Current Download Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="136"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="453"/>
+        <source>Current Upload Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="137"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="455"/>
+        <source>Total Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="138"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="457"/>
+        <source>Total Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="139"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="459"/>
+        <source>Total Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="140"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="461"/>
+        <source>Total Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="141"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="463"/>
+        <source>Total Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="142"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="465"/>
+        <source>Total Click Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="143"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="467"/>
+        <source>Total Key Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="144"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="469"/>
+        <source>Total Download Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="145"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="471"/>
+        <source>Total Upload Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="146"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="473"/>
+        <source>Rank Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="147"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="475"/>
+        <source>Rank Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="148"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="477"/>
+        <source>Rank Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="149"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="479"/>
+        <source>Rank Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="150"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="481"/>
+        <source>Rank Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="151"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="483"/>
+        <source>Today Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="152"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="485"/>
+        <source>Today Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="153"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="487"/>
+        <source>Today Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="154"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="489"/>
+        <source>Today Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="173"/>
+        <source>Snap to grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="179"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="200"/>
+        <source>Call to Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="256"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="264"/>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="268"/>
+        <source>Background color: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="272"/>
+        <source>Font color: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="282"/>
+        <source>Font size: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="301"/>
+        <source>Transparency: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="320"/>
+        <source>Close Geek Window on double click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="326"/>
+        <source>Put Geek Window on top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="594"/>
+        <source>Reset to default?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="595"/>
+        <source>Do you want to reset the Geek Window to default?
+This will reset any custom layouts!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTabIgnoredApps</name>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="15"/>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="31"/>
+        <source>Network interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="50"/>
+        <source>On this page you can manage applications and network interfaces that you&apos;ve chosen to ignore. Right click an application or interface to manage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="58"/>
+        <source>&lt;b&gt;Ignored network interfaces&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="86"/>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="121"/>
+        <source>No applications ignored</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="112"/>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="184"/>
+        <source>No network interfaces ignored</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="126"/>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="189"/>
+        <source>Unignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="132"/>
+        <source>Open file location</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTabMilestones</name>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="21"/>
+        <source>Milestones let you create notifications when you cross certain statistics. Use the &apos;Add&apos; button to create a milestone and doubleclick on the Milestone to edit it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="27"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="46"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="74"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="307"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="46"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="75"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="308"/>
+        <source>Statistic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="47"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="75"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="308"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="47"/>
+        <source>Actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="74"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="307"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="87"/>
+        <source>&lt;h2&gt;History&lt;/h2&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="164"/>
+        <source>Milestone Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="170"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="282"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="418"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="170"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="282"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="420"/>
+        <source>Clicks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="170"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="282"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="422"/>
+        <source>Downloaded MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="171"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="283"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="425"/>
+        <source>Uploaded MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="171"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="283"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="428"/>
+        <source>Uptime in Minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="195"/>
+        <source>Delete Milestone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="196"/>
+        <source>Are you sure you want to delete this Milestone?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="239"/>
+        <source>Time for coffee, you&apos;ve made X keys!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="243"/>
+        <source>Milestone Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="244"/>
+        <source>Display a custom message when this Milestone hits:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="395"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="399"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="403"/>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="407"/>
+        <source>Please input 100 or higher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="412"/>
+        <source>Please input 10 or higher.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsTabProxy</name>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="16"/>
+        <source>Use manual proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="17"/>
+        <source>Auto detect proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="18"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="409"/>
+        <source> Test proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="20"/>
+        <source>Proxy authentication required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="98"/>
+        <source>Enable Client API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="148"/>
+        <source>Hostname:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="151"/>
+        <source>Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="167"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="170"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="202"/>
+        <source>Client API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="209"/>
+        <source>The Client API is a way to extract real-time information from the WhatPulse client. You can use this to feed your data into another application. Find out more in our &lt;a href=&quot;http://dev.whatpulse.org&quot;&gt;Developer Center&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="230"/>
+        <source>Listen on port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="236"/>
+        <source>Enter a value between 1024 and 65535</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="253"/>
+        <source>IPs that are allowed to connect (one per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="371"/>
+        <source>Not enough info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="372"/>
+        <source>Please fill out both the proxy hostname and port number before testing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="378"/>
+        <source> Testing..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="415"/>
+        <source>Success!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="415"/>
+        <source>Proxy test worked!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="417"/>
+        <source>Proxy test error!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TaskTrayPopup</name>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="209"/>
+        <source>Pulse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="215"/>
+        <source>Open Client</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="221"/>
+        <source>View Online Stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="227"/>
+        <source>Toggle Geek Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="234"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="240"/>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="245"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="253"/>
+        <source>Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="259"/>
+        <source>Check for Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="265"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="271"/>
+        <source>Exit WhatPulse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimePeriod</name>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="43"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="75"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="210"/>
+        <source>real-time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="48"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="77"/>
+        <source>today</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="52"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="79"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="133"/>
+        <source>yesterday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="56"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="81"/>
+        <source>week</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="60"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="83"/>
+        <source>month</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="63"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="85"/>
+        <source>6 months</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="64"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="87"/>
+        <source>year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="70"/>
+        <source>all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="71"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="89"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="217"/>
+        <source>custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimePeriodCustomTimeWindow_IntroPage</name>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="363"/>
+        <source>Select the start and end date of the period you&apos;d like to see statistics from.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="365"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="369"/>
+        <source>From:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/widgets/timeperiod.cpp" line="381"/>
+        <source>To:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TrayMenuItemStats</name>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="105"/>
+        <source>Keys:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="106"/>
+        <source>Clicks:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="107"/>
+        <source>Uptime:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="108"/>
+        <source>Down:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="109"/>
+        <source>Up:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="118"/>
+        <source>Keys: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="123"/>
+        <source>Clicks: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="129"/>
+        <source>Down: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="132"/>
+        <source>Up: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/tasktraypopup.cpp" line="139"/>
+        <source>Uptime: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UploadDatabaseWindow</name>
+    <message>
+        <location filename="../interface/UploadDatabaseWindow.cpp" line="45"/>
+        <source>Uploading database...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UploadDatabaseWindow.cpp" line="52"/>
+        <location filename="../interface/UploadDatabaseWindow.cpp" line="123"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UploadDatabaseWindow.cpp" line="63"/>
+        <source>Upload database?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UploadDatabaseWindow.cpp" line="63"/>
+        <source>Did a developer ask you to upload your database?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UploadDatabaseWindow.cpp" line="105"/>
+        <source> left</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UptimePage</name>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1018"/>
+        <source>Exporting Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1019"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1025"/>
+        <source>Please make your exporting selection below. Select what data you want, then the timespan and whether you want to group it per day, week or month and press Save to export as CSV.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1033"/>
+        <source>Total uptime per application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1035"/>
+        <source>Active time used per application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1036"/>
+        <source>List of your reboots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1054"/>
+        <source>Export from:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1065"/>
+        <source>to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1085"/>
+        <source>Group by:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1088"/>
+        <location filename="../interface/ExportWindow.cpp" line="1290"/>
+        <location filename="../interface/ExportWindow.cpp" line="1311"/>
+        <location filename="../interface/ExportWindow.cpp" line="1314"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1089"/>
+        <source>Day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1090"/>
+        <location filename="../interface/ExportWindow.cpp" line="1294"/>
+        <source>Week</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1091"/>
+        <location filename="../interface/ExportWindow.cpp" line="1298"/>
+        <source>Month</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1101"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1109"/>
+        <source>Premium Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1118"/>
+        <source>Working..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1142"/>
+        <source>You have selected a date range larger than 90 days. Exporting may take a while.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1212"/>
+        <source>Reboot list between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1242"/>
+        <source>Application uptime </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1283"/>
+        <source>Active application time between &apos;%1&apos; and &apos;%2&apos; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1291"/>
+        <source>grouped by Hour </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1295"/>
+        <source>grouped by Week </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1299"/>
+        <source>grouped by Month </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/ExportWindow.cpp" line="1303"/>
+        <source>grouped by Day </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UptimeTab</name>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="50"/>
+        <source>Computer Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="52"/>
+        <source>Reboot Calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="54"/>
+        <source>Applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="56"/>
+        <source>Application Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="70"/>
+        <source> Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="84"/>
+        <location filename="../interface/UptimeTab.cpp" line="98"/>
+        <source>Uptime - Computer Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="86"/>
+        <location filename="../interface/UptimeTab.cpp" line="99"/>
+        <source>Uptime - Reboot Calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="88"/>
+        <location filename="../interface/UptimeTab.cpp" line="100"/>
+        <source>Uptime - Applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="90"/>
+        <location filename="../interface/UptimeTab.cpp" line="101"/>
+        <source>Uptime - Application Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="92"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="140"/>
+        <location filename="../interface/UptimeTab.cpp" line="271"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="152"/>
+        <location filename="../interface/UptimeTab.cpp" line="283"/>
+        <source>&amp;Export to .csv</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="156"/>
+        <location filename="../interface/UptimeTab.cpp" line="286"/>
+        <source>&amp;Export Wizard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="186"/>
+        <source>Go Premium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="205"/>
+        <source>&lt;h3&gt;Favorite reboot days&lt;/h3&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="231"/>
+        <source>Sun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="231"/>
+        <source>Mon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="231"/>
+        <source>Tue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="231"/>
+        <source>Wed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="232"/>
+        <source>Thu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="232"/>
+        <source>Fri</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="232"/>
+        <source>Sat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="247"/>
+        <source>Show only recently used applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="254"/>
+        <source>Show only running applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="305"/>
+        <location filename="../interface/UptimeTab.cpp" line="306"/>
+        <location filename="../interface/UptimeTab.cpp" line="307"/>
+        <location filename="../interface/UptimeTab.cpp" line="308"/>
+        <location filename="../interface/UptimeTab.cpp" line="309"/>
+        <location filename="../interface/UptimeTab.cpp" line="310"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="321"/>
+        <source>Unpulsed uptime:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="324"/>
+        <source>Current uptime:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="327"/>
+        <source>Total uptime:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="330"/>
+        <source>Longest uptime:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="333"/>
+        <source>Average uptime:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="336"/>
+        <source>Total reboots:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="346"/>
+        <source>Reboot history for </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="391"/>
+        <source>No reboots found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="404"/>
+        <source>Reboot history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="463"/>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="463"/>
+        <source>Total time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="464"/>
+        <source>Total active time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="491"/>
+        <source>Ignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="497"/>
+        <source>Open File Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="503"/>
+        <source>Open Online Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="518"/>
+        <source>Ignore application?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="519"/>
+        <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="570"/>
+        <source>Not yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="571"/>
+        <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="908"/>
+        <location filename="../interface/UptimeTab.cpp" line="914"/>
+        <source>uptime and reboot data (all except per application) </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="909"/>
+        <location filename="../interface/UptimeTab.cpp" line="915"/>
+        <source>Reset Uptime/Reboot History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="919"/>
+        <location filename="../interface/UptimeTab.cpp" line="924"/>
+        <source>application uptime data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="920"/>
+        <location filename="../interface/UptimeTab.cpp" line="925"/>
+        <source>Reset Application History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="929"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="931"/>
+        <source>Do you want to reset all uptime data or just the %1?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="934"/>
+        <source>Reset All Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="949"/>
+        <location filename="../interface/UptimeTab.cpp" line="967"/>
+        <location filename="../interface/UptimeTab.cpp" line="985"/>
+        <location filename="../interface/UptimeTab.cpp" line="1000"/>
+        <location filename="../interface/UptimeTab.cpp" line="1008"/>
+        <location filename="../interface/UptimeTab.cpp" line="1025"/>
+        <source>Delete stats?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="950"/>
+        <location filename="../interface/UptimeTab.cpp" line="968"/>
+        <source>Are you sure you want to delete all (except per application) recorded uptime statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="986"/>
+        <location filename="../interface/UptimeTab.cpp" line="1009"/>
+        <source>Are you sure you want to delete all recorded per application uptime statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="1001"/>
+        <source>Are you sure you want to delete all recorded keyboard and mouse statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/UptimeTab.cpp" line="1026"/>
+        <source>Are you sure you want to delete all recorded uptime statistics? This cannot be undone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Utils</name>
+    <message>
+        <location filename="../utils.cpp" line="74"/>
+        <source>&lt;1 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="74"/>
+        <source>Less than a minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="81"/>
+        <source>1 year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="83"/>
+        <source>%1 years</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="89"/>
+        <source>1 day</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="91"/>
+        <source>%1 days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="97"/>
+        <source>1 hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="99"/>
+        <source>%1 hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="106"/>
+        <source>1 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="108"/>
+        <source>1 minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="111"/>
+        <source>%1 min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="113"/>
+        <source>%1 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="376"/>
+        <source>th</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="379"/>
+        <source>st</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="381"/>
+        <source>nd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="383"/>
+        <source>rd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="472"/>
+        <source>Sunday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="474"/>
+        <source>Monday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="476"/>
+        <source>Tuesday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="478"/>
+        <source>Wednesday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="480"/>
+        <source>Thursday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="482"/>
+        <source>Friday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="484"/>
+        <source>Saturday</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="982"/>
+        <location filename="../utils.cpp" line="1008"/>
+        <source>Save as...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="995"/>
+        <location filename="../utils.cpp" line="1023"/>
+        <source>Export Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="996"/>
+        <location filename="../utils.cpp" line="1024"/>
+        <source>Opening export file failed! Please try again in another directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1034"/>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1037"/>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1040"/>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1043"/>
+        <source>Capslock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1046"/>
+        <source>Left Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1049"/>
+        <source>Left Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1052"/>
+        <source>Left Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1055"/>
+        <source>Right Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1058"/>
+        <source>Right Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1061"/>
+        <source>Right Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1064"/>
+        <source>Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1067"/>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1070"/>
+        <source>Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1073"/>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1076"/>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1079"/>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1082"/>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1085"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1088"/>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1091"/>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1094"/>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1136"/>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1253"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils.cpp" line="1391"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>wHTTP</name>
+    <message>
+        <location filename="../online/whttp.cpp" line="129"/>
+        <location filename="../online/whttp.cpp" line="371"/>
+        <source>SSL errors, something fishy is going on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/whttp.cpp" line="529"/>
+        <source>SSL Connection to website failed! This could be our fault, but it could also be a proxy trying to peek into our communication. Please disable the proxy, if that&apos;s the case.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>wHTTPServerResponder</name>
+    <message>
+        <location filename="../online/whttpserver_responder.cpp" line="23"/>
+        <source>Execute a pulse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/whttpserver_responder.cpp" line="28"/>
+        <source>Index of all possible calls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/whttpserver_responder.cpp" line="33"/>
+        <source>Get all unpulsed stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/whttpserver_responder.cpp" line="38"/>
+        <source>Get all total account stats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/whttpserver_responder.cpp" line="44"/>
+        <source>Get real-time information (keys per second, current download, etc)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../online/whttpserver_responder.cpp" line="101"/>
+        <source>{ &quot;error&quot;: &quot;Unable to parse information.&quot;}</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>wizardAuthorizationPage</name>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="21"/>
+        <source>You have been redirected to the website, please follow the instructions there. After you finish the login procedure, the client will automagically log in and you&apos;re off to the races!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="38"/>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="80"/>
+        <source>Waiting on authorization via website..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="130"/>
+        <source>If your browser did not open, try clicking or copying &lt;a href=&quot;%1&quot;&gt;this link&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="149"/>
+        <source>Our server is currently in maintenance, please check back in a few minutes. Sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="162"/>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="175"/>
+        <source>Our server producing errors, please check back in a few minutes. Sorry!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="320"/>
+        <source>Restore Database?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="321"/>
+        <source>Good news! I found your previous client database backups, do you want to restore?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="330"/>
+        <source>Restore Settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="331"/>
+        <source>Good news! I found your previous client settings, do you want to load them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>wizardMainPage</name>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardMainPage.cpp" line="11"/>
+        <source>Welcome to WhatPulse, &lt;b&gt;the only&lt;/b&gt; statistics program you&apos;ll ever need. WhatPulse answers the question &apos;How much do I use my computer in one day?&apos;&lt;br /&gt;&lt;br /&gt;Let&apos;s get started. If you already have an account, please click &lt;b&gt;Login&lt;/b&gt;. If you are new to WhatPulse, please click &lt;b&gt;Register&lt;/b&gt;.&lt;br /&gt;&lt;br /&gt;In both cases you&apos;ll be redirected to our website to complete the login.&lt;br /&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardMainPage.cpp" line="25"/>
+        <source>Login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardMainPage.cpp" line="27"/>
+        <source>Register Account</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>wizardRestoreSettingsPage</name>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="72"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="72"/>
+        <source>Computer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="73"/>
+        <source>Backup Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="106"/>
+        <source>Almost there! Select a database from the list below and click Finish to download and restore.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="109"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="112"/>
+        <source>Almost there! Click Finish to apply your previous client settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="162"/>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="170"/>
+        <source>Cannot proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="163"/>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="171"/>
+        <source>Please select a database backup file from the list before you proceed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="190"/>
+        <source>Contacting website..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="398"/>
+        <source>Starting download..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="401"/>
+        <source>Premium only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="402"/>
+        <source>Sorry, the online backup feature is for Premium members only. There&apos;s more information here: https://whatpulse.org/premium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="407"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="408"/>
+        <source>Sorry, the website gave an error preparing for your backup. Please try again later. Here&apos;s the error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="423"/>
+        <source>Downloading backup..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="431"/>
+        <source>Download completed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="439"/>
+        <source>Extracting database..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="460"/>
+        <source>All done! Please restart the client by clicking Finished.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="462"/>
+        <source>Finished</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>wizardSettingsPage</name>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="24"/>
+        <source>Almost there! Set up the most important settings here. Click an option to see more detail.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="59"/>
+        <source>1. Measure your Keyboard &amp; Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="67"/>
+        <source>When this option is enabled, WhatPulse will count your keystrokes and mouse clicks. It counts the times a specific key of button has been pressed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="76"/>
+        <source>Also send to the website for use in your Dashboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="87"/>
+        <source>2. Measure Network Traffic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="95"/>
+        <source>This option has WhatPulse look at your networking traffic and measure the bytes of data going through your computer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="109"/>
+        <source>3. Measure Computer Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="117"/>
+        <source>Ever wondered how long your computer is turned on? This option will tell you just that. As a part of uptime, this will also tell you how long you&apos;re using specific applications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="129"/>
+        <source>4. Measure Application Usage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="137"/>
+        <source>What apps do you use the most? Which apps download the most? This will provide you with insight.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="145"/>
+        <source>Also send online for your Dashboard &amp; Apps Overview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="159"/>
+        <source>&lt;small&gt;If you want to collect all stats, but not show them publicly, check out your &lt;a href=&quot;https://whatpulse.org/dashboard/my/privacy&quot;&gt;privacy settings&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/whatpulse_zh_CN.ts
+++ b/whatpulse_zh_CN.ts
@@ -1,87 +1,90 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ts_ZA">
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AccountTab</name>
     <message>
         <location filename="../interface/AccountTab.cpp" line="26"/>
         <source>Account information</source>
-        <translation>账户信息</translation>
+        <translatorcomment>“账户”的账字使用贝字旁，与钱相关，似乎更加适用于“银行账户”这样的上下文。</translatorcomment>
+        <translation>帐户信息</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="37"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>用户名：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="39"/>
         <source>UserID:</source>
-        <translation type="unfinished"></translation>
+        <translation>用户 ID：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="42"/>
         <source>Computer:</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>或者“设备名”？</translatorcomment>
+        <translation>计算机名：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="44"/>
         <source>Email:</source>
-        <translation type="unfinished"></translation>
+        <translation>电子邮箱：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="46"/>
         <source>Premium:</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>这个有点难翻译，“会员”？“高级版”？</translatorcomment>
+        <translation>尊享版：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="70"/>
         <source>Total Keys:</source>
-        <translation type="unfinished"></translation>
+        <translation>总按键：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="72"/>
         <source>Total Clicks:</source>
-        <translation type="unfinished"></translation>
+        <translation>总点击：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="74"/>
         <source>Total Download:</source>
-        <translation type="unfinished"></translation>
+        <translation>总下载：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="76"/>
         <source>Total Upload:</source>
-        <translation type="unfinished"></translation>
+        <translation>总上传：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="78"/>
         <source>Total Uptime:</source>
-        <translation type="unfinished"></translation>
+        <translation>总上线：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="132"/>
         <source> &amp;View Online Stats</source>
-        <translation type="unfinished"></translation>
+        <translation> 查看线上统计(&amp;V)</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="140"/>
         <source> &amp;Log out</source>
-        <translation type="unfinished"></translation>
+        <translation> 退出(&amp;L)</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="148"/>
         <source> &amp;Reset Token</source>
-        <translation type="unfinished"></translation>
+        <translation> 重置(&amp;R)</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="156"/>
         <source> Change &amp;Password</source>
-        <translation type="unfinished"></translation>
+        <translation> 修改密码(&amp;P)</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="165"/>
         <source> Refresh &amp;Account</source>
-        <translation type="unfinished"></translation>
+        <translation> 刷新帐户(&amp;A)</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="219"/>
@@ -90,49 +93,49 @@
         <location filename="../interface/AccountTab.cpp" line="237"/>
         <location filename="../interface/AccountTab.cpp" line="243"/>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="247"/>
         <source>Yes (expires at %1)</source>
-        <translation type="unfinished"></translation>
+        <translation>是（截至 %1）</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="251"/>
         <location filename="../interface/AccountTab.cpp" line="317"/>
         <location filename="../interface/AccountTab.cpp" line="347"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>否</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="310"/>
         <source>Log Out</source>
-        <translation type="unfinished"></translation>
+        <translation>登出</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="312"/>
         <source>Logging out of your account will reset your unpulsed statistics if you login to a different account (database is preserved) and restart the Setup Assistant.</source>
-        <translation type="unfinished"></translation>
+        <translation>如果你退出登录并使用不同的帐户重新登录的话，那么未 Pulse 的统计将被重置（但是数据库会保留），并将重新启动设置向导。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="316"/>
         <source>Do you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>是否继续？</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="317"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>是</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="332"/>
         <source>Change Password</source>
-        <translation type="unfinished"></translation>
+        <translation>修改密码</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="333"/>
         <source>You can&apos;t change your password inside the client. Please log out and log back in with the same email address and computer name to change your password in this client. Your stats will be preserved if you use the same details.</source>
-        <translation type="unfinished"></translation>
+        <translation>无法在客户端里修改密码。请退出登录，然后使用相同的邮箱和计算机名重新登录以在客户端里修改密码。使用相同的信息时统计会保留。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="338"/>
@@ -140,65 +143,68 @@
         <location filename="../interface/AccountTab.cpp" line="383"/>
         <location filename="../interface/AccountTab.cpp" line="450"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>好的</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="343"/>
         <location filename="../interface/AccountTab.cpp" line="380"/>
         <source>Reset your token</source>
-        <translation type="unfinished"></translation>
+        <translation>重置令牌</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="344"/>
         <source>Resetting your token will reset your local statistics and allow you to pulse again.</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Pulse 保留不翻译了吧</translatorcomment>
+        <translation>重置令牌将重置你的本地统计，并允许你重新 Pulse。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="346"/>
         <source>Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>确定？</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="347"/>
         <source>Yes, reset token</source>
-        <translation type="unfinished"></translation>
+        <translation>确定，重置令牌</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="375"/>
         <source>Token reset!</source>
-        <translation type="unfinished"></translation>
+        <translation>令牌已重置！</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="376"/>
         <source>Token reset!
 
 You can continue pulsing.</source>
-        <translation type="unfinished"></translation>
+        <translation>令牌已重置！
+
+你可以重新 Pulse 了。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="381"/>
         <source>Something went wrong while resetting your token:</source>
-        <translation type="unfinished"></translation>
+        <translation>重置令牌时出错：</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="440"/>
         <source>Premium Membership</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享版会员</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="441"/>
         <source>Your premium membership has just been activated!</source>
-        <translation type="unfinished"></translation>
+        <translation>你的尊享版会员已激活！</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="447"/>
         <source>Refresh Account Status</source>
-        <translation type="unfinished"></translation>
+        <translation>刷新帐户状态</translation>
     </message>
     <message>
         <location filename="../interface/AccountTab.cpp" line="448"/>
         <source>Something went wrong while refreshing your account data:</source>
-        <translation type="unfinished"></translation>
+        <translation>刷新帐户数据时出错：</translation>
     </message>
 </context>
 <context>
@@ -206,17 +212,17 @@ You can continue pulsing.</source>
     <message>
         <location filename="../interface/AccountTabWizard.cpp" line="35"/>
         <source>Finish</source>
-        <translation type="unfinished"></translation>
+        <translation>完成</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard.cpp" line="40"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>返回</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard.cpp" line="96"/>
         <source>Welcome to WhatPulse</source>
-        <translation type="unfinished"></translation>
+        <translation>欢迎使用 WhatPulse</translation>
     </message>
 </context>
 <context>
@@ -224,123 +230,124 @@ You can continue pulsing.</source>
     <message>
         <location filename="../application.cpp" line="234"/>
         <source>No system tray</source>
-        <translation type="unfinished"></translation>
+        <translation>没有系统托盘</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="235"/>
         <source>Couldn&apos;t detect any system tray on this system, and I need that to run.</source>
-        <translation type="unfinished"></translation>
+        <translation>检测不到系统托盘，我启动不了。</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="253"/>
         <source>AES functions not available. Are libeay32.dll and ssleay32.dll present? If not, try reinstalling!</source>
-        <translation type="unfinished"></translation>
+        <translation>无法使用 AES 函数。有没有 libeay32.dll 和 ssleay32.dll？如果没有的话，重装试试看！</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="257"/>
         <source>AES functions not available. Is OpenSSL library present?</source>
-        <translation type="unfinished"></translation>
+        <translation>无法使用 AES 函数。有没有 OpenSSL 库？</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="260"/>
         <source>AES failure</source>
-        <translation type="unfinished"></translation>
+        <translation>AES 失败</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="337"/>
         <source>Cleanup Required</source>
-        <translation type="unfinished"></translation>
+        <translation>需要清理</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="338"/>
         <source>I have detected a required cleanup after your update of just now. For the sake of cleanliness, I will run the cleanup program (whatpulse-after-update.exe) before loading. You might get a permission authorization request.</source>
-        <translation type="unfinished"></translation>
+        <translation>我检测到你刚刚的更新需要进行一个清理。我将在加载前运行清理程序（whatpulse-after-update.exe）。你可能会遇到一个权限验证请求。</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="872"/>
         <source>&amp;Open Window</source>
-        <translation type="unfinished"></translation>
+        <translation>打开窗口(&amp;O)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="876"/>
         <source>&amp;Toggle Geek Window</source>
-        <translation type="unfinished"></translation>
+        <translation>显示 / 隐藏悬浮窗(&amp;T)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="880"/>
         <source>&amp;Open Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>打开设置(&amp;O)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="884"/>
         <source>&amp;Check for Updates</source>
-        <translation type="unfinished"></translation>
+        <translation>检查更新(&amp;C)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="888"/>
         <source>&amp;Pulse!</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Pulse！</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="891"/>
         <source>&amp;View Online Stats</source>
-        <translation type="unfinished"></translation>
+        <translation>查看线上统计(&amp;V)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="895"/>
         <source>&amp;Quit WhatPulse</source>
-        <translation type="unfinished"></translation>
+        <translation>退出 WhatPulse(&amp;Q)</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="898"/>
         <source>Enabled Stats</source>
-        <translation type="unfinished"></translation>
+        <translation>开启统计</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="899"/>
         <source>Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="900"/>
         <source>Keyboard Heatmap</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘热力图</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="901"/>
         <source>Mouse</source>
-        <translation type="unfinished"></translation>
+        <translation>鼠标</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="902"/>
         <source>Mouse Heatmap</source>
-        <translation type="unfinished"></translation>
+        <translation>鼠标热力图</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="903"/>
         <source>Network</source>
-        <translation type="unfinished"></translation>
+        <translation>网络</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="904"/>
         <source>Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1349"/>
         <source>Pulsing Disabled!</source>
-        <translation type="unfinished"></translation>
+        <translation>已禁用 Pulse！</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1350"/>
         <source>The setting &quot;Work Offline&quot; is enabled. This prevents the client from going online, which includes pulsing. Disable that setting and you can pulse again.</source>
-        <translation type="unfinished"></translation>
+        <translation>“脱机工作”已开启。已阻止包括 Pulse 在内的全部在线操作。如果需要重新 Pulse 的话请关闭该设置。</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1537"/>
         <source>You have enabled Portable Mode. This should only be used when placing WhatPulse on a portable media, like an USB drive.
 Do you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>你已打开绿色模式。只有在你准备将 WhatPulse 移动到一个类似于 U 盘之类的便携媒体的时候才应当使用这个模式。
+是否继续？</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1540"/>
@@ -350,53 +357,57 @@ Do you want to continue?</source>
         <location filename="../application.cpp" line="1638"/>
         <location filename="../application.cpp" line="1649"/>
         <source>Portable Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>绿色模式</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1560"/>
         <source>Copying the database to %1 failed! Check write permissions.
 Disabling Portable Mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>复制数据库到 %1 时失败！请检查写权限。
+正在禁用绿色模式。</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1576"/>
         <source>Copying the statistics file to %1 failed! Check write permissions.
 Disabling Portable Mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>复制统计文件到 %1 时失败！请检查写权限。
+正在禁用绿色模式。</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1596"/>
         <location filename="../application.cpp" line="1650"/>
         <source>I rearranged some database files and need to restart myself, see you in a bit!</source>
-        <translation type="unfinished"></translation>
+        <translation>我重新安排了一些数据库文件，然后需要重启自己。一会见！</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1619"/>
         <source>Copying the database to %1 failed! Check write permissions.
 Keeping Portable Mode enabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>复制数据库到 %1 失败！请检查写权限。
+绿色模式依然启用。</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="1635"/>
         <source>Copying the statistics file to %1 failed! Check write permissions.
 Keeping Portable Mode enabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>复制统计文件到 %1 失败。请检查写权限。
+绿色模式依然启用。</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="2024"/>
         <location filename="../application.cpp" line="2037"/>
         <source>Premium features disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享功能已禁用</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="2025"/>
         <source>I was not able to contact the website to verify your premium membership for 96 hours. I have disabled the premium features. Go back online to enable again.</source>
-        <translation type="unfinished"></translation>
+        <translation>我已经有 96 小时无法联网检查你的尊享版资格了。我已经禁用了你的尊享版功能。联网再重试。</translation>
     </message>
     <message>
         <location filename="../application.cpp" line="2038"/>
         <source>Your premium membership has expired so I have disabled the premium features. You can reactivate your membership via the website.</source>
-        <translation type="unfinished"></translation>
+        <translation>你的尊享版会员已经过期，所以我已经禁用了你的尊享版功能。你可以通过这个网页重新激活你的资格。</translation>
     </message>
 </context>
 <context>
@@ -404,7 +415,7 @@ Keeping Portable Mode enabled.</source>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="65"/>
         <source>Report a Bug</source>
-        <translation type="unfinished"></translation>
+        <translation>报告缺陷</translation>
     </message>
 </context>
 <context>
@@ -412,67 +423,67 @@ Keeping Portable Mode enabled.</source>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="98"/>
         <source>Send Report</source>
-        <translation type="unfinished"></translation>
+        <translation>发送报告</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="107"/>
         <source>Page</source>
-        <translation type="unfinished"></translation>
+        <translation>页</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="111"/>
         <source>Send Database?</source>
-        <translation type="unfinished"></translation>
+        <translation>发送数据库？</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="117"/>
         <source>Description:</source>
-        <translation type="unfinished"></translation>
+        <translation>描述：</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="135"/>
         <source>Send Database</source>
-        <translation type="unfinished"></translation>
+        <translation>发送数据库</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="136"/>
         <source>When you select &apos;Send Database&apos; - a copy of your local database will be sent to the WhatPulse developers so they can more easily reproduce issues.&lt;br /&gt;&lt;br /&gt;Your database is: </source>
-        <translation type="unfinished"></translation>
+        <translation>当你选择“发送数据库”时，你的本地数据库将被拷贝一份并发送至 WhatPulse 开发者手中以便复现问题。&lt;br /&gt;&lt;br /&gt;你的数据库是： </translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="145"/>
         <source>No Description</source>
-        <translation type="unfinished"></translation>
+        <translation>无题</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="146"/>
         <source>Please enter a description of the issue you are running into.</source>
-        <translation type="unfinished"></translation>
+        <translation>请描述一下你遇到的问题。</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="196"/>
         <source>Thanks!</source>
-        <translation type="unfinished"></translation>
+        <translation>谢谢！</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="197"/>
         <source>Bug Report successfully sent, thanks for reporting!</source>
-        <translation type="unfinished"></translation>
+        <translation>成功发送缺陷报告。谢谢你的报告！</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="203"/>
         <source>Uh oh</source>
-        <translation type="unfinished"></translation>
+        <translation>芜湖</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="204"/>
         <source>Something went wrong while reporting your bug. Please try again!&lt;br /&gt;&lt;br /&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>报告缺陷时出错。请重试！&lt;br /&gt;&lt;br /&gt;</translation>
     </message>
     <message>
         <location filename="../interface/BugReportWindow.cpp" line="218"/>
         <source>Other</source>
-        <translation type="unfinished"></translation>
+        <translation>其他</translation>
     </message>
 </context>
 <context>
@@ -480,98 +491,98 @@ Keeping Portable Mode enabled.</source>
     <message>
         <location filename="../online/clientcommunication.cpp" line="230"/>
         <source>The website is not responding correctly to your request, please try again later.</source>
-        <translation type="unfinished"></translation>
+        <translation>网站未正确响应你的请求，请稍后再试。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="258"/>
         <source>Your account is pending activation, please check your email and try again after activating.</source>
-        <translation type="unfinished"></translation>
+        <translation>你的帐户未激活，请检查邮箱进行激活后再试。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="262"/>
         <location filename="../online/clientcommunication.cpp" line="318"/>
         <source>Account or computer unknown! Did you register?</source>
-        <translation type="unfinished"></translation>
+        <translation>未知的帐户或计算机名！你注册了吗？</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="265"/>
         <location filename="../online/clientcommunication.cpp" line="321"/>
         <source>Wrong password! Try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>密码错误！请重试。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="269"/>
         <location filename="../online/clientcommunication.cpp" line="345"/>
         <source>Server is down due to maintenance, please try again later.</source>
-        <translation type="unfinished"></translation>
+        <translation>服务器维护中，请稍后再试。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="272"/>
         <location filename="../online/clientcommunication.cpp" line="348"/>
         <source>Internal server error. Please try again later.</source>
-        <translation type="unfinished"></translation>
+        <translation>服务器内部错误。请稍后再试。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="276"/>
         <location filename="../online/clientcommunication.cpp" line="352"/>
         <source>Server error: Missing input! Please contact the developers.</source>
-        <translation type="unfinished"></translation>
+        <translation>服务器错误：没有输入！请联系开发者。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="324"/>
         <source>Activity throttled breached, this means your keys or clicks per second is too high. Wait an hour or so to lower it and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>活动超过了限制，这意味着你的每秒按键或每秒点击过高了。等待一小时左右以降低它，然后再重试。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="330"/>
         <source>Wrong token, did you use this profile on another computer?</source>
-        <translation type="unfinished"></translation>
+        <translation>错误的令牌，你是否在别的计算机上使用了相同的信息？</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="333"/>
         <source>Requested username is already registered! Please choose another username and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>用户名已被占用！请使用别的用户名重试。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="338"/>
         <source>Pulse throttled. You can only pulse every 60 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation>Pulse 限制。每 60 秒只允许 Pulse 一次。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="341"/>
         <source>Premium only feature.</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享版特权。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="355"/>
         <location filename="../online/clientcommunication.cpp" line="874"/>
         <source>Success.</source>
-        <translation type="unfinished"></translation>
+        <translation>成功。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="358"/>
         <source>Success, your file is now on the website!</source>
-        <translation type="unfinished"></translation>
+        <translation>成功，你的信息已经在网页上了！</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="863"/>
         <source>Unable to open GeoIP database (%1), permission denied.</source>
-        <translation type="unfinished"></translation>
+        <translation>无法打开地理 IP 数据库（%1），拒绝访问。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="925"/>
         <source>Empty reply received</source>
-        <translation type="unfinished"></translation>
+        <translation>收到空响应</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="947"/>
         <source>Unable to open Network Port Description database (%1), permission denied.</source>
-        <translation type="unfinished"></translation>
+        <translation>无法打开网络端口描述数据库（%1），拒绝访问。</translation>
     </message>
     <message>
         <location filename="../online/clientcommunication.cpp" line="961"/>
         <source>Downloaded file does not look good: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>下载的文件不大对劲： %1</translation>
     </message>
 </context>
 <context>
@@ -580,46 +591,48 @@ Keeping Portable Mode enabled.</source>
         <location filename="../util/database.cpp" line="54"/>
         <location filename="../util/database.cpp" line="66"/>
         <source>Database failure</source>
-        <translation type="unfinished"></translation>
+        <translation>数据库异常</translation>
     </message>
     <message>
         <location filename="../util/database.cpp" line="55"/>
         <source>Unable to setup database: %1
 
 Please check your permissions on: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>无法设置数据库：%1
+
+请检查你在 %2 的权限</translation>
     </message>
     <message>
         <location filename="../util/database.cpp" line="67"/>
         <source>Unable to setup database: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>无法设置数据库：%1</translation>
     </message>
     <message>
         <location filename="../util/database.cpp" line="152"/>
         <source>The database &apos;%1&apos; is read-only. WhatPulse cannot store any statistics until you fix this problem.</source>
-        <translation type="unfinished"></translation>
+        <translation>数据库“%1”是只读模式。在修复这个问题之前 WhatPulse 无法存储任何统计。</translation>
     </message>
     <message>
         <location filename="../util/database.cpp" line="196"/>
         <location filename="../util/database.cpp" line="228"/>
         <source>Critical database error!</source>
-        <translation type="unfinished"></translation>
+        <translation>数据库严重损坏！</translation>
     </message>
     <message>
         <location filename="../util/database.cpp" line="197"/>
         <location filename="../util/database.cpp" line="229"/>
         <source>Something really bad happened to the database and the backup database. The only way to recover is to create a new database. This will not effect your unpulsed stats, but will wipe the rest. Continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>数据库与备份数据库均出现严重问题。唯一的恢复方式是创建新数据库。这不会影响你尚未 Pulse 的统计，但剩下的一切将被抹除。继续？</translation>
     </message>
     <message>
         <location filename="../util/database.cpp" line="347"/>
         <source>Version</source>
-        <translation type="unfinished"></translation>
+        <translation>版本</translation>
     </message>
     <message>
         <location filename="../util/database.cpp" line="348"/>
         <source>It is not supported to downgrade the WhatPulse client, please install the latest version and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>WhatPulse 客户端不支持降级，请安装最新版本重试。</translation>
     </message>
 </context>
 <context>
@@ -627,68 +640,68 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="42"/>
         <source>WhatPulse Database Backup</source>
-        <translation type="unfinished"></translation>
+        <translation>WhatPulse 数据库备份</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="55"/>
         <source>Hi there! According to my records, it&apos;s been &lt;b&gt;%1&lt;/b&gt; days since your last online database backup. Please take a minute and do so now. This window will close automatically when I&apos;m done.</source>
-        <translation type="unfinished"></translation>
+        <translation>你好呀！根据我的记录，你已经有 &lt;b&gt;%1&lt;/b&gt; 天没有在线备份数据库了。请花一分钟备份一下。备份完成之后这个窗口会自动关闭。</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="67"/>
         <source>Your database is &lt;b&gt;%1&lt;/b&gt;, which should take around &lt;b&gt;%2&lt;/b&gt; to upload.</source>
-        <translation type="unfinished"></translation>
+        <translation>你的数据库是 &lt;b&gt;%1&lt;/b&gt;，上传大概需要花费 &lt;b&gt;%2&lt;/b&gt;。</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="89"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="96"/>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="112"/>
         <source>Start Backup</source>
-        <translation type="unfinished"></translation>
+        <translation>开始备份</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="126"/>
         <source>Checking with website..</source>
-        <translation type="unfinished"></translation>
+        <translation>检查网页中…</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="161"/>
         <source>Premium only</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享版独享</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="162"/>
         <source>Sorry, the online backup feature is for Premium members only. There&apos;s more information here: https://whatpulse.org/premium</source>
-        <translation type="unfinished"></translation>
+        <translation>抱歉，在线备份功能仅面向尊享版。更多信息：https://whatpulse.org/premium</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="171"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>错误</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="172"/>
         <source>Sorry, the website gave an error preparing for your backup. Please try again later. Here&apos;s the error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>抱歉，准备你的备份时网站出错。请稍后再试。错误是： %1</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="184"/>
         <source>Zipping database..</source>
-        <translation type="unfinished"></translation>
+        <translation>压缩数据库中…</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="205"/>
         <source>Starting upload..</source>
-        <translation type="unfinished"></translation>
+        <translation>上传中…</translation>
     </message>
     <message>
         <location filename="../interface/DatabaseBackupWindow.cpp" line="223"/>
         <source>All done!</source>
-        <translation type="unfinished"></translation>
+        <translation>好了！</translation>
     </message>
 </context>
 <context>
@@ -696,7 +709,7 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="22"/>
         <source>WhatPulse Export Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation>WhatPulse 导出向导</translation>
     </message>
 </context>
 <context>
@@ -705,12 +718,12 @@ Please check your permissions on: %2</source>
         <location filename="../interface/FactsWindow.cpp" line="15"/>
         <location filename="../interface/FactsWindow.cpp" line="53"/>
         <source>Facts</source>
-        <translation type="unfinished"></translation>
+        <translation>事实</translation>
     </message>
     <message>
         <location filename="../interface/FactsWindow.cpp" line="94"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
 </context>
 <context>
@@ -718,27 +731,27 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="14"/>
         <source>Software Update</source>
-        <translation type="unfinished"></translation>
+        <translation>软件更新</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="20"/>
         <source>The update file is located at:</source>
-        <translation type="unfinished"></translation>
+        <translation>更新文件位于：</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="27"/>
         <source>&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="40"/>
         <source>Download this update, close &quot;%1&quot;, install it, and then reopen &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation>下载该更新，关闭“%1”，安装它，然后重新打开“%1“。</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdateconfirmdialog.ui" line="47"/>
         <source>When you click &quot;OK&quot;, this link will be opened in your browser.</source>
-        <translation type="unfinished"></translation>
+        <translation>点击”好的“将在浏览器中打开该链接。</translation>
     </message>
 </context>
 <context>
@@ -746,17 +759,18 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatedownloadprogress.ui" line="23"/>
         <source>FvUpdateDownloadProgress</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>保留原文？</translatorcomment>
+        <translation>FvUpdateDownloadProgress</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatedownloadprogress.ui" line="70"/>
         <source>Downloading Update...</source>
-        <translation type="unfinished"></translation>
+        <translation>下载更新中…</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatedownloadprogress.ui" line="98"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
 </context>
 <context>
@@ -764,37 +778,37 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="26"/>
         <source>Software Update</source>
-        <translation type="unfinished"></translation>
+        <translation>软件更新</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="43"/>
         <source>A new version of %1 is available!</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 有新版本了！</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="50"/>
         <source>%1 %2 is now available - you have %3. Would you like to download it now?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 有 %2 了，而你在 %3。现在下载它？</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="63"/>
         <source>Release Notes:</source>
-        <translation type="unfinished"></translation>
+        <translation>发行说明：</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="77"/>
         <source>Skip This Version</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略该版本</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="97"/>
         <source>Remind Me Later</source>
-        <translation type="unfinished"></translation>
+        <translation>稍后提醒我</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdatewindow.ui" line="104"/>
         <source>Install Update</source>
-        <translation type="unfinished"></translation>
+        <translation>安装更新</translation>
     </message>
 </context>
 <context>
@@ -806,57 +820,58 @@ Please check your permissions on: %2</source>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="466"/>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="470"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>错误</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="310"/>
         <source>Feed download failed: %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Feed 下载失败：%1。</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="429"/>
         <source>Feed parsing failed: %1 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Feed 解析失败：%1 %2。</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="457"/>
         <source>Feed error: &quot;release notes&quot; link is empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Feed 错误：“发行说明”为空</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="466"/>
         <source>Feed error: invalid &quot;release notes&quot; link</source>
-        <translation type="unfinished"></translation>
+        <translation>Feed 错误：“发行说明”链接无效</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="470"/>
         <source>Feed error: invalid &quot;enclosure&quot; with the download link</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>enclosure 的上下文是啥？</translatorcomment>
+        <translation>Feed 错误：下载链接的”附件“无效</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="477"/>
         <source>Updater</source>
-        <translation type="unfinished"></translation>
+        <translation>更新器</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="477"/>
         <source>&lt;b&gt;You&apos;re up to date!&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;whatpulse %1 is currently the newest version available.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;已是最新！&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;WhatPulse %1 是当前可用的最新版。</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="560"/>
         <source>SSL fingerprint check: The url %1 is not a ssl connection!</source>
-        <translation type="unfinished"></translation>
+        <translation>SSL 指纹检查：URL %1 不是 SSL 链接！</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="653"/>
         <source>Unable to open</source>
-        <translation type="unfinished"></translation>
+        <translation>无法打开</translation>
     </message>
     <message>
         <location filename="../3rdparty/fervor-autoupdate/fvupdater.cpp" line="653"/>
         <source>Unable to open this link in a browser. Please try manually.</source>
-        <translation type="unfinished"></translation>
+        <translation>无法在浏览器中打开该链接。请手动重试。</translation>
     </message>
 </context>
 <context>
@@ -864,92 +879,92 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="144"/>
         <source>Exporting Input</source>
-        <translation type="unfinished"></translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="145"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="151"/>
         <source>Please make your exporting selection below. Select what data you want, then the timespan and whether you want to group it per day, week or month and press Save to export as CSV.</source>
-        <translation type="unfinished"></translation>
+        <translation>请选择你要导出的项目。选择你需要的数据，然后是时间段和你想要的分组，每天、每周或者每月，点击”保存“以导出 CSV 文件。</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="158"/>
         <source>History of Keys and Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>按键与点击历史</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="159"/>
         <source>Heatmap of Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>按键热力图</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="160"/>
         <source>Heatmap of Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>点击热力图</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="161"/>
         <source>Application Keys and Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>分应用的按键与点击</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="173"/>
         <source>Export from:</source>
-        <translation type="unfinished"></translation>
+        <translation>导出自：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="183"/>
         <source>to:</source>
-        <translation type="unfinished"></translation>
+        <translation>到：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="202"/>
         <source>Group by:</source>
-        <translation type="unfinished"></translation>
+        <translation>分组：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="204"/>
         <source>Hour</source>
-        <translation type="unfinished"></translation>
+        <translation>时</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="205"/>
         <source>Day</source>
-        <translation type="unfinished"></translation>
+        <translation>日</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="206"/>
         <source>Week</source>
-        <translation type="unfinished"></translation>
+        <translation>周</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="207"/>
         <source>Month</source>
-        <translation type="unfinished"></translation>
+        <translation>月</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="217"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>保存</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="225"/>
         <source>Premium Only</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享版独享</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="234"/>
         <source>Working..</source>
-        <translation type="unfinished"></translation>
+        <translation>进行中…</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="279"/>
         <source>History of keys and clicks between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的按键与点击历史 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="297"/>
@@ -957,21 +972,21 @@ Please check your permissions on: %2</source>
         <location filename="../interface/ExportWindow.cpp" line="454"/>
         <location filename="../interface/ExportWindow.cpp" line="504"/>
         <source>grouped by Week </source>
-        <translation type="unfinished"></translation>
+        <translation>按周分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="308"/>
         <location filename="../interface/ExportWindow.cpp" line="392"/>
         <location filename="../interface/ExportWindow.cpp" line="512"/>
         <source>grouped by Month </source>
-        <translation type="unfinished"></translation>
+        <translation>按月分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="321"/>
         <location filename="../interface/ExportWindow.cpp" line="401"/>
         <location filename="../interface/ExportWindow.cpp" line="522"/>
         <source>grouped by Hour </source>
-        <translation type="unfinished"></translation>
+        <translation>按小时分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="332"/>
@@ -979,37 +994,37 @@ Please check your permissions on: %2</source>
         <location filename="../interface/ExportWindow.cpp" line="467"/>
         <location filename="../interface/ExportWindow.cpp" line="530"/>
         <source>grouped by Day </source>
-        <translation type="unfinished"></translation>
+        <translation>按天分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="374"/>
         <source>Heatmap of keys between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的按键热力图 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="436"/>
         <source>Heatmap of clicks between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的点击热力图 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="443"/>
         <source>Unsupported Grouping</source>
-        <translation type="unfinished"></translation>
+        <translation>不支持的分组</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="444"/>
         <source>Unfortunately, per hour grouping on the mouse heat map is not supported. I&apos;ve changed the grouping to per day.</source>
-        <translation type="unfinished"></translation>
+        <translation>抱歉，不支持每小时分组的点击热力图。我已经改成了每天分组。</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="492"/>
         <source>Application input between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的分应用输入 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="577"/>
         <source>You have selected a date range larger than 90 days. Exporting may take a while.</source>
-        <translation type="unfinished"></translation>
+        <translation>你选了一个超过 90 天的时间范围。导出可能需要一会。</translation>
     </message>
 </context>
 <context>
@@ -1023,7 +1038,7 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="1151"/>
         <location filename="../interface/InputTab.cpp" line="1161"/>
         <source>Keys:</source>
-        <translation type="unfinished"></translation>
+        <translation>按键：</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="72"/>
@@ -1034,80 +1049,81 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="1152"/>
         <location filename="../interface/InputTab.cpp" line="1162"/>
         <source>Clicks:</source>
-        <translation type="unfinished"></translation>
+        <translation>点击：</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="99"/>
         <source>Keyboard Heatmap</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘热力图</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="100"/>
         <source>Mouse Heatmap</source>
-        <translation type="unfinished"></translation>
+        <translation>鼠标热力图</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="101"/>
         <source>Applications</source>
-        <translation type="unfinished"></translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="102"/>
         <source>Input History</source>
-        <translation type="unfinished"></translation>
+        <translation>输入历史</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="104"/>
         <source>Key Combinations</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>按键组合？</translatorcomment>
+        <translation>组合键</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="125"/>
         <source> Reset</source>
-        <translation type="unfinished"></translation>
+        <translation> 重置</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="191"/>
         <source>Combination</source>
-        <translation type="unfinished"></translation>
+        <translation>组合</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="191"/>
         <source>Used</source>
-        <translation type="unfinished"></translation>
+        <translation>使用次数</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="208"/>
         <source>Hide Shift only</source>
-        <translation type="unfinished"></translation>
+        <translation>隐藏纯 Shift</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="217"/>
         <source>Hide Ctrl only</source>
-        <translation type="unfinished"></translation>
+        <translation>隐藏纯 Ctrl</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="286"/>
         <source>Date</source>
-        <translation type="unfinished"></translation>
+        <translation>日期</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="286"/>
         <location filename="../interface/InputTab.cpp" line="1069"/>
         <source>Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>按键</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="287"/>
         <location filename="../interface/InputTab.cpp" line="508"/>
         <location filename="../interface/InputTab.cpp" line="1069"/>
         <source>Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>点击</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="297"/>
         <source>Go Premium</source>
-        <translation type="unfinished"></translation>
+        <translation>开始尊享版</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="306"/>
@@ -1115,7 +1131,7 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="724"/>
         <location filename="../interface/InputTab.cpp" line="1099"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="319"/>
@@ -1123,14 +1139,14 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="736"/>
         <location filename="../interface/InputTab.cpp" line="1111"/>
         <source>&amp;Export to .csv</source>
-        <translation type="unfinished"></translation>
+        <translation>导出为 CSV 格式(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="323"/>
         <location filename="../interface/InputTab.cpp" line="446"/>
         <location filename="../interface/InputTab.cpp" line="740"/>
         <source>&amp;Export to .png</source>
-        <translation type="unfinished"></translation>
+        <translation>导出为 PNG 格式(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="328"/>
@@ -1138,129 +1154,129 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="744"/>
         <location filename="../interface/InputTab.cpp" line="1115"/>
         <source>&amp;Export Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="348"/>
         <source>Last 12 hours</source>
-        <translation type="unfinished"></translation>
+        <translation>最近 12 小时</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="349"/>
         <source>Last 24 hours</source>
-        <translation type="unfinished"></translation>
+        <translation>最近 24 小时</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="350"/>
         <source>Last 7 days</source>
-        <translation type="unfinished"></translation>
+        <translation>最近 7 天</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="351"/>
         <source>Last 7 weeks</source>
-        <translation type="unfinished"></translation>
+        <translation>最近 7 周</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="352"/>
         <source>Last 7 months</source>
-        <translation type="unfinished"></translation>
+        <translation>最近 7 个月</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="355"/>
         <source>Group by Hours</source>
-        <translation type="unfinished"></translation>
+        <translation>每小时分组</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="356"/>
         <source>Group by Days</source>
-        <translation type="unfinished"></translation>
+        <translation>每日分组</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="357"/>
         <source>Group by Weeks</source>
-        <translation type="unfinished"></translation>
+        <translation>每周分组</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="359"/>
         <source>Group by Months</source>
-        <translation type="unfinished"></translation>
+        <translation>每月分组</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="360"/>
         <source>Group by Years</source>
-        <translation type="unfinished"></translation>
+        <translation>每年分组</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="407"/>
         <location filename="../interface/InputTab.cpp" line="711"/>
         <source>Enable Heatmap</source>
-        <translation type="unfinished"></translation>
+        <translation>开启热力图</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="417"/>
         <source>Prune older than 3 months</source>
-        <translation type="unfinished"></translation>
+        <translation>丢弃 3 个月以上的历史</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="459"/>
         <location filename="../interface/InputTab.cpp" line="752"/>
         <source>Share</source>
-        <translation type="unfinished"></translation>
+        <translation>分享</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="502"/>
         <source>&lt;b&gt;Buttons Usage&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;按键使用&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="508"/>
         <source>Button</source>
-        <translation type="unfinished"></translation>
+        <translation>按键</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="537"/>
         <source>Mouse heat map selected</source>
-        <translation type="unfinished"></translation>
+        <translation>已选择鼠标热力图</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="541"/>
         <source>Switch to button view</source>
-        <translation type="unfinished"></translation>
+        <translation>切换至按键界面</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="548"/>
         <source>Switch to mouse heat map</source>
-        <translation type="unfinished"></translation>
+        <translation>切换至鼠标热力图</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="553"/>
         <source>Button view selected</source>
-        <translation type="unfinished"></translation>
+        <translation>已选择按键界面</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="637"/>
         <source>Key</source>
-        <translation type="unfinished"></translation>
+        <translation>按键</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="637"/>
         <source>Amount</source>
-        <translation type="unfinished"></translation>
+        <translation>数量</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="679"/>
         <source>Layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>布局：</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="770"/>
         <source>Application:</source>
-        <translation type="unfinished"></translation>
+        <translation>应用：</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="777"/>
         <source>Per-App Stats Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>已禁用分应用统计</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="777"/>
@@ -1271,7 +1287,7 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="1880"/>
         <location filename="../interface/InputTab.cpp" line="1881"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>全部</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="780"/>
@@ -1280,73 +1296,73 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="1880"/>
         <location filename="../interface/InputTab.cpp" line="1881"/>
         <source>Premium Only</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享版独享</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="841"/>
         <location filename="../interface/InputTab.cpp" line="1140"/>
         <source>&lt;b&gt;Today&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;今天&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="853"/>
         <location filename="../interface/InputTab.cpp" line="1150"/>
         <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;昨天&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="865"/>
         <source>&lt;b&gt;Unpulsed&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;未 Pulse&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="877"/>
         <location filename="../interface/InputTab.cpp" line="1160"/>
         <source>&lt;b&gt;All time&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;全部&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="936"/>
         <source>Keyboard heat map selected</source>
-        <translation type="unfinished"></translation>
+        <translation>已选择键盘热力图</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="940"/>
         <location filename="../interface/InputTab.cpp" line="1009"/>
         <source>Switch to table view</source>
-        <translation type="unfinished"></translation>
+        <translation>切换至表格界面</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="948"/>
         <source>Switch to keyboard heat map</source>
-        <translation type="unfinished"></translation>
+        <translation>切换至键盘热力图</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="953"/>
         <location filename="../interface/InputTab.cpp" line="1021"/>
         <source>Table view selected</source>
-        <translation type="unfinished"></translation>
+        <translation>已选择表格界面</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="1005"/>
         <source>Chart view selected</source>
-        <translation type="unfinished"></translation>
+        <translation>已选择图表界面</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="1016"/>
         <source>Switch to chart view</source>
-        <translation type="unfinished"></translation>
+        <translation>切换至图表界面</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="1069"/>
         <source>Application</source>
-        <translation type="unfinished"></translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="1132"/>
         <location filename="../interface/InputTab.cpp" line="1986"/>
         <source>Summary</source>
-        <translation type="unfinished"></translation>
+        <translation>总结</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="1135"/>
@@ -1358,102 +1374,102 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="2864"/>
         <location filename="../interface/InputTab.cpp" line="2865"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="1904"/>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="1965"/>
         <source>&lt;b&gt;You have disabled per application input statistics in the Settings.&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;你在设置中禁用了分应用输入统计。&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="1993"/>
         <source>Summary of </source>
-        <translation type="unfinished"></translation>
+        <translation>总结 </translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2093"/>
         <source>Left</source>
-        <translation type="unfinished"></translation>
+        <translation>左键</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2093"/>
         <source>Middle</source>
-        <translation type="unfinished"></translation>
+        <translation>中键</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2093"/>
         <source>Right</source>
-        <translation type="unfinished"></translation>
+        <translation>右键</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2093"/>
         <source>Other</source>
-        <translation type="unfinished"></translation>
+        <translation>其他</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2469"/>
         <source>keyboard historical data</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘历史数据</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2474"/>
         <source>mouse historical data</source>
-        <translation type="unfinished"></translation>
+        <translation>鼠标历史数据</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2475"/>
         <source>Reset Mouse History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置鼠标历史</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2479"/>
         <source>application historical data</source>
-        <translation type="unfinished"></translation>
+        <translation>应用历史数据</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2480"/>
         <source>Reset Application History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置应用历史</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2484"/>
         <source>keyboard and mouse historical data</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘与鼠标历史数据</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2485"/>
         <source>Reset Keyboard and Mouse History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置键盘与鼠标历史数据</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2489"/>
         <source>key combination historical data</source>
-        <translation type="unfinished"></translation>
+        <translation>按键组合历史数据</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2490"/>
         <source>Reset Key Combinations History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置按键组合历史数据</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2494"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2496"/>
         <source>Do you want to reset all input data or just the </source>
-        <translation type="unfinished"></translation>
+        <translation>你是准备重置全部输入数据还是说只是</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2499"/>
         <source>Reset All Data</source>
-        <translation type="unfinished"></translation>
+        <translation>重置全部数据</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2514"/>
@@ -1463,87 +1479,87 @@ Please check your permissions on: %2</source>
         <location filename="../interface/InputTab.cpp" line="2592"/>
         <location filename="../interface/InputTab.cpp" line="2608"/>
         <source>Delete stats?</source>
-        <translation type="unfinished"></translation>
+        <translation>删除统计？</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2515"/>
         <source>Are you sure you want to delete all recorded keyboard statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部键盘统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2535"/>
         <source>Are you sure you want to delete all recorded mouse statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部鼠标统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2556"/>
         <source>Are you sure you want to delete all recorded per application input statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部分应用统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2569"/>
         <source>Are you sure you want to delete all recorded keyboard and mouse statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部键盘与鼠标统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2593"/>
         <source>Are you sure you want to delete all recorded key combination statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部按键组合统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2609"/>
         <source>Are you sure you want to delete all recorded input statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部输入统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2638"/>
         <source>No input devices found, are your &lt;a href=&quot;http://whatpulse.org/kb/content/7/15/en/linux-installation.html&quot;&gt;permissions&lt;/a&gt; set up correctly?</source>
-        <translation type="unfinished"></translation>
+        <translation>未找到输入设备，你的&lt;a href=&quot;http://whatpulse.org/kb/content/7/15/en/linux-installation.html&quot;&gt;权限&lt;/a&gt;设置对了吗？</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2719"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2725"/>
         <source>Open File Location</source>
-        <translation type="unfinished"></translation>
+        <translation>打开文件路径</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2731"/>
         <source>Open Online Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>打开线上个人页</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2746"/>
         <source>Ignore application?</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略应用？</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2747"/>
         <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定忽略应用”%1“？这将同时移除该应用的历史。</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2800"/>
         <source>Not yet</source>
-        <translation type="unfinished"></translation>
+        <translation>先不要</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2801"/>
         <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
-        <translation type="unfinished"></translation>
+        <translation>该应用尚未上传到网站，请一小时左右之后再试。</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2824"/>
         <source>Prune Mouse Heatmap</source>
-        <translation type="unfinished"></translation>
+        <translation>丢弃鼠标热力图</translation>
     </message>
     <message>
         <location filename="../interface/InputTab.cpp" line="2825"/>
         <source>By not pruning your mouse heatmap, your database will get pretty large and possibly slow WhatPulse down. Stop pruning?</source>
-        <translation type="unfinished"></translation>
+        <translation>如果不丢弃鼠标热力图的话，数据库将会变得相当大并拖慢 WhatPulse。停止丢弃？</translation>
     </message>
 </context>
 <context>
@@ -1551,37 +1567,37 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="62"/>
         <source>Export Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation>导出向导</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="68"/>
         <source>Welcome to the Export Wizard. This wizard allows you to export all your data inside the WhatPulse client into a CSV file. Pick a statistic and press Next!</source>
-        <translation type="unfinished"></translation>
+        <translation>欢迎使用导出向导。该向导将协助你导出该 WhatPulse 客户端的全部数据到一个 CSV 文件。选择一个统计并继续！</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="75"/>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation>输入</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="76"/>
         <source>Network</source>
-        <translation type="unfinished"></translation>
+        <translation>网络</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="77"/>
         <source>Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="93"/>
         <source>This advanced export wizard is a &lt;b&gt;premium only&lt;/b&gt; feature. You can browse to see the possibilities, but you need a premium subscription to export data.</source>
-        <translation type="unfinished"></translation>
+        <translation>该高级导出向导是&lt;b&gt;尊享版特权&lt;/b&gt;功能。你可以看看有什么可以选择，但是真要导出数据的话还是需要一个尊享版订阅。</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="105"/>
         <source>Go Premium</source>
-        <translation type="unfinished"></translation>
+        <translation>开始尊享版</translation>
     </message>
 </context>
 <context>
@@ -1589,32 +1605,32 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="421"/>
         <source>Image not created!</source>
-        <translation type="unfinished"></translation>
+        <translation>图像未创建！</translation>
     </message>
     <message>
         <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="422"/>
         <source>Unable to generate heatmap image. Please try again or check permissions on: </source>
-        <translation type="unfinished"></translation>
+        <translation>无法生成热力图图像。请重试并检查权限： </translation>
     </message>
     <message>
         <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="460"/>
         <source>Pressed</source>
-        <translation type="unfinished"></translation>
+        <translation>按了</translation>
     </message>
     <message>
         <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="515"/>
         <source>Image posted online!</source>
-        <translation type="unfinished"></translation>
+        <translation>图像贴到线上啦！</translation>
     </message>
     <message>
         <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="516"/>
         <source>Keyboard image succesfully uploaded! Do you want to view it in your browser?</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘图像成功上传！在浏览器看看不？</translation>
     </message>
     <message>
         <location filename="../interface/widgets/KeyboardHeatmap.cpp" line="528"/>
         <source>Error uploading file!</source>
-        <translation type="unfinished"></translation>
+        <translation>上传文件错误！</translation>
     </message>
 </context>
 <context>
@@ -1622,17 +1638,17 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../stats/localstats.cpp" line="231"/>
         <source>Pulse throttled!</source>
-        <translation type="unfinished"></translation>
+        <translation>Pulse 限制！</translation>
     </message>
     <message>
         <location filename="../stats/localstats.cpp" line="232"/>
         <source>Pulse throttled! Your last pulse was %1 seconds ago, please try again in 10 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation>Pulse 限制！%1 秒前刚刚 Pulse 过，请 10 秒后重试。</translation>
     </message>
     <message>
         <location filename="../stats/localstats.cpp" line="308"/>
         <source>Error while pulsing!</source>
-        <translation type="unfinished"></translation>
+        <translation>Pulse 错误！</translation>
     </message>
 </context>
 <context>
@@ -1640,34 +1656,34 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/MainWindow.cpp" line="196"/>
         <source>Overview</source>
-        <translation type="unfinished"></translation>
+        <translation>总览</translation>
     </message>
     <message>
         <location filename="../interface/MainWindow.cpp" line="197"/>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation>输入</translation>
     </message>
     <message>
         <location filename="../interface/MainWindow.cpp" line="198"/>
         <source>Network</source>
-        <translation type="unfinished"></translation>
+        <translation>网络</translation>
     </message>
     <message>
         <location filename="../interface/MainWindow.cpp" line="199"/>
         <source>Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长</translation>
     </message>
     <message>
         <location filename="../interface/MainWindow.cpp" line="200"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>设置</translation>
     </message>
     <message>
         <location filename="../interface/MainWindow.cpp" line="203"/>
         <location filename="../interface/MainWindow.cpp" line="256"/>
         <location filename="../interface/MainWindow.cpp" line="303"/>
         <source>Account</source>
-        <translation type="unfinished"></translation>
+        <translation>帐户</translation>
     </message>
 </context>
 <context>
@@ -1675,17 +1691,17 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/widgets/MouseButtons.cpp" line="27"/>
         <source>Right</source>
-        <translation type="unfinished"></translation>
+        <translation>右键</translation>
     </message>
     <message>
         <location filename="../interface/widgets/MouseButtons.cpp" line="30"/>
         <source>Left</source>
-        <translation type="unfinished"></translation>
+        <translation>左键</translation>
     </message>
     <message>
         <location filename="../interface/widgets/MouseButtons.cpp" line="33"/>
         <source>Middle</source>
-        <translation type="unfinished"></translation>
+        <translation>中键</translation>
     </message>
 </context>
 <context>
@@ -1693,27 +1709,27 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/widgets/MouseHeatmap.cpp" line="98"/>
         <source>Image not created!</source>
-        <translation type="unfinished"></translation>
+        <translation>图像未创建！</translation>
     </message>
     <message>
         <location filename="../interface/widgets/MouseHeatmap.cpp" line="99"/>
         <source>Unable to generate heatmap image. Please try again or check permissions on: </source>
-        <translation type="unfinished"></translation>
+        <translation>无法生成热力图图像。请重试并检查权限： </translation>
     </message>
     <message>
         <location filename="../interface/widgets/MouseHeatmap.cpp" line="281"/>
         <source>Image posted online!</source>
-        <translation type="unfinished"></translation>
+        <translation>图像贴到线上啦！</translation>
     </message>
     <message>
         <location filename="../interface/widgets/MouseHeatmap.cpp" line="282"/>
         <source>Mouse heatmap succesfully uploaded! Do you want to view it in your browser?</source>
-        <translation type="unfinished"></translation>
+        <translation>鼠标图像成功上传！在浏览器看看不？</translation>
     </message>
     <message>
         <location filename="../interface/widgets/MouseHeatmap.cpp" line="294"/>
         <source>Error uploading file!</source>
-        <translation type="unfinished"></translation>
+        <translation>上传文件错误！</translation>
     </message>
 </context>
 <context>
@@ -1721,22 +1737,22 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="561"/>
         <source>Show Wired</source>
-        <translation type="unfinished"></translation>
+        <translation>显示有线</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="563"/>
         <source>Hide Wired</source>
-        <translation type="unfinished"></translation>
+        <translation>隐藏有线</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="572"/>
         <source>Show Wifi</source>
-        <translation type="unfinished"></translation>
+        <translation>显示无线</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="574"/>
         <source>Hide Wifi</source>
-        <translation type="unfinished"></translation>
+        <translation>隐藏无线</translation>
     </message>
 </context>
 <context>
@@ -1744,57 +1760,57 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="587"/>
         <source>Exporting Network</source>
-        <translation type="unfinished"></translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="588"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="594"/>
         <source>Please make your exporting selection below. Select what data you want, then the timespan and whether you want to group it per day, week or month and press Save to export as CSV.</source>
-        <translation type="unfinished"></translation>
+        <translation>请选择你要导出的项目。选择你需要的数据，然后是时间段和你想要的分组，每天、每周或者每月，点击”保存“以导出 CSV 文件。</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="601"/>
         <source>Traffic per application</source>
-        <translation type="unfinished"></translation>
+        <translation>分应用流量</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="602"/>
         <source>Traffic per country</source>
-        <translation type="unfinished"></translation>
+        <translation>分国家流量</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="603"/>
         <source>Traffic per network interface</source>
-        <translation type="unfinished"></translation>
+        <translation>分网卡流量</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="604"/>
         <source>Traffic per type</source>
-        <translation type="unfinished"></translation>
+        <translation>分类型流量</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="616"/>
         <source>Export from:</source>
-        <translation type="unfinished"></translation>
+        <translation>导出自：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="626"/>
         <source>to:</source>
-        <translation type="unfinished"></translation>
+        <translation>到：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="645"/>
         <source>Group by:</source>
-        <translation type="unfinished"></translation>
+        <translation>分组：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="647"/>
         <source>Day</source>
-        <translation type="unfinished"></translation>
+        <translation>日</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="648"/>
@@ -1803,7 +1819,7 @@ Please check your permissions on: %2</source>
         <location filename="../interface/ExportWindow.cpp" line="865"/>
         <location filename="../interface/ExportWindow.cpp" line="928"/>
         <source>Week</source>
-        <translation type="unfinished"></translation>
+        <translation>周</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="649"/>
@@ -1812,27 +1828,27 @@ Please check your permissions on: %2</source>
         <location filename="../interface/ExportWindow.cpp" line="873"/>
         <location filename="../interface/ExportWindow.cpp" line="937"/>
         <source>Month</source>
-        <translation type="unfinished"></translation>
+        <translation>月</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="659"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>保存</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="667"/>
         <source>Premium Only</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享版独享</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="676"/>
         <source>Working..</source>
-        <translation type="unfinished"></translation>
+        <translation>进行中…</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="719"/>
         <source>Network interface traffic between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的网卡流量 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="749"/>
@@ -1840,7 +1856,7 @@ Please check your permissions on: %2</source>
         <location filename="../interface/ExportWindow.cpp" line="872"/>
         <location filename="../interface/ExportWindow.cpp" line="936"/>
         <source>grouped by Week </source>
-        <translation type="unfinished"></translation>
+        <translation>按周分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="757"/>
@@ -1848,7 +1864,7 @@ Please check your permissions on: %2</source>
         <location filename="../interface/ExportWindow.cpp" line="880"/>
         <location filename="../interface/ExportWindow.cpp" line="945"/>
         <source>grouped by Month </source>
-        <translation type="unfinished"></translation>
+        <translation>按月分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="765"/>
@@ -1856,32 +1872,32 @@ Please check your permissions on: %2</source>
         <location filename="../interface/ExportWindow.cpp" line="888"/>
         <location filename="../interface/ExportWindow.cpp" line="954"/>
         <source>grouped by Day </source>
-        <translation type="unfinished"></translation>
+        <translation>按天分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="784"/>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="801"/>
         <source>Network per applications between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的分应用流量 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="860"/>
         <source>Country network traffic between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的国家流量 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="923"/>
         <source>Network per type between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的分类型流量 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1008"/>
         <source>You have selected a date range larger than 90 days. Exporting may take a while.</source>
-        <translation type="unfinished"></translation>
+        <translation>你选了一个超过 90 天的时间范围。导出可能需要一会。</translation>
     </message>
 </context>
 <context>
@@ -1889,112 +1905,112 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="46"/>
         <source>Interfaces</source>
-        <translation type="unfinished"></translation>
+        <translation>网卡</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="47"/>
         <source>Applications</source>
-        <translation type="unfinished"></translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="48"/>
         <source>Realtime Bandwidth</source>
-        <translation type="unfinished"></translation>
+        <translation>实时带宽</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="49"/>
         <source>Bandwidth per Country</source>
-        <translation type="unfinished"></translation>
+        <translation>分国家带宽</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="50"/>
         <source>Traffic Types</source>
-        <translation type="unfinished"></translation>
+        <translation>流量类型</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="69"/>
         <source> Reset</source>
-        <translation type="unfinished"></translation>
+        <translation> 重置</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="144"/>
         <source>Your GeoIP database is empty, per country stats won&apos;t work. Click &lt;a href=&quot;#&quot;&gt;here&lt;/a&gt; to refresh the database.</source>
-        <translation type="unfinished"></translation>
+        <translation>你的地理 IP 数据库是空的，分国家统计无法工作。点击&lt;a href=&quot;#&quot;&gt;这里&lt;/a&gt;刷新数据库。</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="178"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>是</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="180"/>
         <source>Yes, with IP </source>
-        <translation type="unfinished"></translation>
+        <translation>确定，IP </translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="183"/>
         <source>Testing..</source>
-        <translation type="unfinished"></translation>
+        <translation>测试中…</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="185"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>否</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="201"/>
         <source>interface historical data</source>
-        <translation type="unfinished"></translation>
+        <translation>网卡历史数据</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="202"/>
         <source>Reset Interface History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置网卡历史</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="206"/>
         <source>per application history data</source>
-        <translation type="unfinished"></translation>
+        <translation>分应用历史数据</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="207"/>
         <source>Reset Application History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置应用历史</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="211"/>
         <source>per country history data</source>
-        <translation type="unfinished"></translation>
+        <translation>分国家历史数据</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="212"/>
         <source>Reset Country History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置国家历史</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="216"/>
         <source>per traffic type data</source>
-        <translation type="unfinished"></translation>
+        <translation>分类型流量数据</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="217"/>
         <source>Reset Traffic Types History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置流量类型历史</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="221"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="223"/>
         <source>Do you want to reset all network data or just the %1?</source>
-        <translation type="unfinished"></translation>
+        <translation>你是准备重置全部网络数据还是说只是%1？</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="226"/>
         <source>Reset All Data</source>
-        <translation type="unfinished"></translation>
+        <translation>重置全部数据</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="241"/>
@@ -2003,68 +2019,68 @@ Please check your permissions on: %2</source>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="283"/>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="299"/>
         <source>Delete stats?</source>
-        <translation type="unfinished"></translation>
+        <translation>删除统计？</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="242"/>
         <source>Are you sure you want to delete all recorded network interface statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部网卡统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="257"/>
         <source>Are you sure you want to delete all recorded per application network statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部分应用网络统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="271"/>
         <source>Are you sure you want to delete all recorded per country network statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部分国家网络统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="284"/>
         <source>Are you sure you want to delete all recorded per traffic type network statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部分类型网络统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="300"/>
         <source>Are you sure you want to delete all recorded network statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部网络统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="368"/>
         <source>Success!</source>
-        <translation type="unfinished"></translation>
+        <translation>成功！</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="368"/>
         <source>GeoIP Database updated succesfully!</source>
-        <translation type="unfinished"></translation>
+        <translation>地理 IP 数据库更新成功！</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="371"/>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="376"/>
         <source>Something went wrong!</source>
-        <translation type="unfinished"></translation>
+        <translation>出错了！</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="372"/>
         <source>GeoIP Database did not update succesfully, unknown error. Please try again later.</source>
-        <translation type="unfinished"></translation>
+        <translation>地理 IP 数据库更新失败，未知错误。请稍后再试。</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="377"/>
         <source>GeoIP Database did not update succesfully, here&apos;s the error: </source>
-        <translation type="unfinished"></translation>
+        <translation>地理 IP 数据库更新失败，错误是： </translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="386"/>
         <source>Npcap not found, which is needed for network statistics.&lt;br&gt;Download at &lt;a href=&quot;https://nmap.org/npcap/&quot;&gt;nmap.org&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>未找到用于网络统计的 Npcap。&lt;br&gt;在 &lt;a href=&quot;https://nmap.org/npcap/&quot;&gt;nmap.org&lt;/a&gt; 下载</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkOverview.cpp" line="390"/>
         <source>LibPcap not found, which is needed for network statistics.&lt;br&gt;Please install package.</source>
-        <translation type="unfinished"></translation>
+        <translation>未找到用于网络统计的 LibPcap。&lt;br&gt;请安装软件包。</translation>
     </message>
 </context>
 <context>
@@ -2072,63 +2088,63 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="19"/>
         <source>Application</source>
-        <translation type="unfinished"></translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="20"/>
         <source>Current download</source>
-        <translation type="unfinished"></translation>
+        <translation>当前下载</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="21"/>
         <source>Current upload</source>
-        <translation type="unfinished"></translation>
+        <translation>当前上传</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="43"/>
         <source>Show only active applications</source>
-        <translation type="unfinished"></translation>
+        <translation>仅显示活跃应用</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="52"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="64"/>
         <source>&amp;Export Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="74"/>
         <source>Go Premium</source>
-        <translation type="unfinished"></translation>
+        <translation>开始尊享版</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="106"/>
         <source>Testing..</source>
-        <translation type="unfinished"></translation>
+        <translation>测试中…</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="110"/>
         <source>Internet:</source>
-        <translation type="unfinished"></translation>
+        <translation>网络：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="116"/>
         <source>Show in bytes</source>
-        <translation type="unfinished"></translation>
+        <translation>以字节计</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="117"/>
         <source>Show in bits</source>
-        <translation type="unfinished"></translation>
+        <translation>以比特计</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="136"/>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="191"/>
         <source>Summary</source>
-        <translation type="unfinished"></translation>
+        <translation>总结</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="139"/>
@@ -2140,87 +2156,87 @@ Please check your permissions on: %2</source>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="539"/>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="540"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="144"/>
         <source>&lt;b&gt;Today&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;今天&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="145"/>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="155"/>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="165"/>
         <source>Downloaded:</source>
-        <translation type="unfinished"></translation>
+        <translation>下载：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="146"/>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="156"/>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="166"/>
         <source>Uploaded:</source>
-        <translation type="unfinished"></translation>
+        <translation>上传：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="154"/>
         <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;昨天&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="164"/>
         <source>&lt;b&gt;All time&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;全部&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="255"/>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="341"/>
         <source>Summary of </source>
-        <translation type="unfinished"></translation>
+        <translation>总结 </translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="388"/>
         <source>(Per-application bandwidth is disabled)</source>
-        <translation type="unfinished"></translation>
+        <translation>（已禁用分应用带宽）</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="394"/>
         <source>Total</source>
-        <translation type="unfinished"></translation>
+        <translation>总</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="405"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="411"/>
         <source>Open File Location</source>
-        <translation type="unfinished"></translation>
+        <translation>打开文件路径</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="417"/>
         <source>Open Online Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>打开线上个人页</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="432"/>
         <source>Ignore application?</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略应用？</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="433"/>
         <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定忽略应用”%1“？这将同时移除该应用的历史。</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="485"/>
         <source>Not yet</source>
-        <translation type="unfinished"></translation>
+        <translation>先不要</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="486"/>
         <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
-        <translation type="unfinished"></translation>
+        <translation>该应用尚未上传到网站，请一小时左右之后再试。</translation>
     </message>
 </context>
 <context>
@@ -2228,62 +2244,62 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="47"/>
         <source>Country</source>
-        <translation type="unfinished"></translation>
+        <translation>国家</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="47"/>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation>下载</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="48"/>
         <source>Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>上传</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="64"/>
         <source>Go Premium</source>
-        <translation type="unfinished"></translation>
+        <translation>开始尊享版</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="82"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="94"/>
         <source>&amp;Export to .csv</source>
-        <translation type="unfinished"></translation>
+        <translation>导出为 CSV 格式(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="97"/>
         <source>&amp;Export to .png</source>
-        <translation type="unfinished"></translation>
+        <translation>导出为 PNG 格式(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="101"/>
         <source>&amp;Export Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="208"/>
         <source>Network heat map selected</source>
-        <translation type="unfinished"></translation>
+        <translation>已选择网络热力图</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="212"/>
         <source>Switch to table view</source>
-        <translation type="unfinished"></translation>
+        <translation>切换至表格界面</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="220"/>
         <source>Switch to network heat map</source>
-        <translation type="unfinished"></translation>
+        <translation>切换至网络热力图</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="225"/>
         <source>Table view selected</source>
-        <translation type="unfinished"></translation>
+        <translation>已选择表格界面</translation>
     </message>
 </context>
 <context>
@@ -2291,52 +2307,52 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="143"/>
         <source>Testing..</source>
-        <translation type="unfinished"></translation>
+        <translation>测试中…</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="147"/>
         <source>Internet:</source>
-        <translation type="unfinished"></translation>
+        <translation>网络：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="151"/>
         <source>Show:</source>
-        <translation type="unfinished"></translation>
+        <translation>显示：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="153"/>
         <source>5 mins</source>
-        <translation type="unfinished"></translation>
+        <translation>5 分钟</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="154"/>
         <source>15 mins</source>
-        <translation type="unfinished"></translation>
+        <translation>15 分钟</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="155"/>
         <source>30 mins</source>
-        <translation type="unfinished"></translation>
+        <translation>30 分钟</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="156"/>
         <source>1 hour</source>
-        <translation type="unfinished"></translation>
+        <translation>1 小时</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="165"/>
         <source>in bytes</source>
-        <translation type="unfinished"></translation>
+        <translation>以字节计</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="166"/>
         <source>in bits</source>
-        <translation type="unfinished"></translation>
+        <translation>以比特计</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="186"/>
         <source>Summary of real-time bandwidth</source>
-        <translation type="unfinished"></translation>
+        <translation>实时带宽总结</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="189"/>
@@ -2346,36 +2362,36 @@ Please check your permissions on: %2</source>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="209"/>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="210"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="194"/>
         <source>&lt;b&gt;Current&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;当前&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="195"/>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="205"/>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="215"/>
         <source>Download:</source>
-        <translation type="unfinished"></translation>
+        <translation>下载：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="196"/>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="206"/>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="216"/>
         <source>Upload:</source>
-        <translation type="unfinished"></translation>
+        <translation>上传：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="204"/>
         <source>&lt;b&gt;Average&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;平均&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkGraph.cpp" line="214"/>
         <source>&lt;b&gt;Maximum&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;最大&lt;/b&gt;</translation>
     </message>
 </context>
 <context>
@@ -2385,72 +2401,72 @@ Please check your permissions on: %2</source>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="479"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="487"/>
         <source>Interface</source>
-        <translation type="unfinished"></translation>
+        <translation>网卡</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="26"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="479"/>
         <source>Current download</source>
-        <translation type="unfinished"></translation>
+        <translation>当前下载</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="27"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="480"/>
         <source>Current upload</source>
-        <translation type="unfinished"></translation>
+        <translation>当前上传</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="27"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="480"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="488"/>
         <source>IP-address</source>
-        <translation type="unfinished"></translation>
+        <translation>IP 地址</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="37"/>
         <source>Total</source>
-        <translation type="unfinished"></translation>
+        <translation>总</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="60"/>
         <source>Show only active interfaces</source>
-        <translation type="unfinished"></translation>
+        <translation>仅显示活跃网卡</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="69"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="81"/>
         <source>&amp;Export Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="106"/>
         <source>Testing..</source>
-        <translation type="unfinished"></translation>
+        <translation>测试中…</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="111"/>
         <source>Internet:</source>
-        <translation type="unfinished"></translation>
+        <translation>网络：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="123"/>
         <source>Show in bytes</source>
-        <translation type="unfinished"></translation>
+        <translation>以字节计</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="124"/>
         <source>Show in bits</source>
-        <translation type="unfinished"></translation>
+        <translation>以比特计</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="142"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="205"/>
         <source>Summary</source>
-        <translation type="unfinished"></translation>
+        <translation>总结</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="145"/>
@@ -2462,61 +2478,61 @@ Please check your permissions on: %2</source>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="373"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="374"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="150"/>
         <source>&lt;b&gt;Today&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;今天&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="151"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="161"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="171"/>
         <source>Downloaded:</source>
-        <translation type="unfinished"></translation>
+        <translation>下载：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="152"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="162"/>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="172"/>
         <source>Uploaded:</source>
-        <translation type="unfinished"></translation>
+        <translation>上传：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="160"/>
         <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;昨天&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="170"/>
         <source>&lt;b&gt;All time&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;全部&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="201"/>
         <source>Summary of Wireless Bandwidth</source>
-        <translation type="unfinished"></translation>
+        <translation>无线带宽总结</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="203"/>
         <source>Summary of Wired Bandwidth</source>
-        <translation type="unfinished"></translation>
+        <translation>有线带宽总结</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="440"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="487"/>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation>下载</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="488"/>
         <source>Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>上传</translation>
     </message>
 </context>
 <context>
@@ -2524,57 +2540,57 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="24"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>类型</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="24"/>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation>协议</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="25"/>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation>下载</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="25"/>
         <source>Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>上传</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="43"/>
         <source>Record unknown traffic types</source>
-        <translation type="unfinished"></translation>
+        <translation>记录未知流量类型</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="56"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="68"/>
         <source>&amp;Export Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="77"/>
         <source>Go Premium</source>
-        <translation type="unfinished"></translation>
+        <translation>开始尊享版</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="102"/>
         <source>Record Unknown Traffic Types</source>
-        <translation type="unfinished"></translation>
+        <translation>记录未知流量类型</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="103"/>
         <source>By recording unknown traffic types, your database will get pretty large and possibly slow WhatPulse down. Still record unknown?</source>
-        <translation type="unfinished"></translation>
+        <translation>如果记录未知流量类型的话，数据库将会变得相当大并拖慢 WhatPulse。依然记录？</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="116"/>
         <source>Summary</source>
-        <translation type="unfinished"></translation>
+        <translation>总结</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="119"/>
@@ -2586,51 +2602,51 @@ Please check your permissions on: %2</source>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="329"/>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="330"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="124"/>
         <source>&lt;b&gt;Today&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="125"/>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="135"/>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="145"/>
         <source>Downloaded:</source>
-        <translation type="unfinished"></translation>
+        <translation>下载：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="126"/>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="136"/>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="146"/>
         <source>Uploaded:</source>
-        <translation type="unfinished"></translation>
+        <translation>上传：</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="134"/>
         <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;昨天&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="144"/>
         <source>&lt;b&gt;All time&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;全部&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="169"/>
         <source>All Traffic</source>
-        <translation type="unfinished"></translation>
+        <translation>全部流量</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="225"/>
         <source>Summary of </source>
-        <translation type="unfinished"></translation>
+        <translation>总结 </translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="268"/>
         <source>(Per-type bandwidth is disabled)</source>
-        <translation type="unfinished"></translation>
+        <translation>（已禁用分类型带宽）</translation>
     </message>
 </context>
 <context>
@@ -2638,127 +2654,134 @@ Please check your permissions on: %2</source>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="38"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; Apple M1 is not fully supported. &lt;a href=&quot;https://help.whatpulse.org/kb/client/whatpulse-support-for-apple-m1&quot;&gt;More info here&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;注意：&lt;/b&gt;苹果 M1 并未完全支持。&lt;a href=&quot;https://help.whatpulse.org/kb/client/whatpulse-support-for-apple-m1&quot;&gt;更多信息&lt;/a&gt;。</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="56"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; According to my records, it&apos;s been &lt;b&gt;%1&lt;/b&gt; days since your last online database backup. Please take a minute &lt;a href=&quot;#&quot;&gt;and do so now&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;注意：&lt;/b&gt;根据我的记录，你已经有 &lt;b&gt;%1&lt;/b&gt; 天没有在线备份数据库了。请花一分钟&lt;a href=&quot;#&quot;&gt;备份&lt;/a&gt;一下。</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="76"/>
         <source>Open Window on Startup</source>
-        <translation type="unfinished"></translation>
+        <translation>启动时打开窗口</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="83"/>
         <source> Pulse!</source>
-        <translation type="unfinished"></translation>
+        <translation> Pulse!</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="103"/>
         <source>Start Online Backup?</source>
-        <translation type="unfinished"></translation>
+        <translation>开始线上备份？</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="104"/>
         <source>Starting a backup will restart the client and show the backup window. Continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>开始备份将重启客户端并显示备份窗口。继续？</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="154"/>
         <source>Current uptime: unknown. Unknown reboots.</source>
-        <translation type="unfinished"></translation>
+        <translation>当前在线时长：未知。重启次数未知。</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="160"/>
         <source>Total keycount: unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>总按键次数：未知</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="166"/>
         <source>Total clickcount: unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>总点击次数：未知</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="172"/>
         <location filename="../interface/OverviewTab.cpp" line="314"/>
         <source>Down: unknown
 Up: unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>下载：未知
+上传：未知</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="192"/>
         <location filename="../interface/OverviewTab.cpp" line="237"/>
         <source>Total: %1
 Available: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>总： %1
+可用： %2</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="260"/>
         <source>Total clickcount: %1
 Unpulsed: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>总点击次数： %1
+未 Pulse： %2</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="273"/>
         <source>Total keycount: %1
 Unpulsed: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>总按键次数： %1
+未 Pulse： %2</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="280"/>
         <location filename="../interface/OverviewTab.cpp" line="281"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="298"/>
         <source>Current uptime: %1. %2 reboots
 Unpulsed: %3</source>
-        <translation type="unfinished"></translation>
+        <translation>当前在线时长： %1。重启次数 %2 次
+未 Pulse： %3</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="310"/>
         <source>Down: %1
 Up: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>下载： %1
+上传： %2</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="318"/>
         <source>%1
 Unpulsed: %2 down, %3 up</source>
-        <translation type="unfinished"></translation>
+        <translation>%1
+未 Pulse：下载 %2，上传 %3</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="328"/>
         <source>The option &apos;Work Offline&apos; is enabled, so you cannot pulse. Disable that option to resume pulsing.</source>
-        <translation type="unfinished"></translation>
+        <translation>“脱机工作”选项已开启，所以你无法 Pulse。关闭该选项以继续 Pulse。</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="339"/>
         <source>Pulsing Disabled!</source>
-        <translation type="unfinished"></translation>
+        <translation>已禁用 Pulse！</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="340"/>
         <source>The setting &quot;Work Offline&quot; is enabled. This prevents the client from going online, which includes pulsing. Disable that setting and you can pulse again.</source>
-        <translation type="unfinished"></translation>
+        <translation>“脱机工作”已开启。已阻止包括 Pulse 在内的全部在线操作。如果需要重新 Pulse 的话请关闭该设置。</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="349"/>
         <source>Pulsing..</source>
-        <translation type="unfinished"></translation>
+        <translation>Pulse…</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="350"/>
         <source>Pulse underway, please wait!</source>
-        <translation type="unfinished"></translation>
+        <translation>正在 Pulse，请稍候！</translation>
     </message>
     <message>
         <location filename="../interface/OverviewTab.cpp" line="355"/>
         <source>Pulse!</source>
-        <translation type="unfinished"></translation>
+        <translation>Pulse!</translation>
     </message>
 </context>
 <context>
@@ -2767,69 +2790,69 @@ Unpulsed: %2 down, %3 up</source>
         <location filename="../interface/mac/permissionsmanager.cpp" line="55"/>
         <location filename="../interface/mac/permissionsmanager.cpp" line="245"/>
         <source>Restart WhatPulse</source>
-        <translation type="unfinished"></translation>
+        <translation>重启 WhatPulse</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="58"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="64"/>
         <location filename="../interface/mac/permissionsmanager.cpp" line="228"/>
         <location filename="../interface/mac/permissionsmanager.cpp" line="247"/>
         <source>Quit WhatPulse</source>
-        <translation type="unfinished"></translation>
+        <translation>退出 WhatPulse</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="100"/>
         <source>&lt;h1&gt;Setup Permissions&lt;/h1&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h1&gt;设置权限&lt;/h1&gt;</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="104"/>
         <source>WhatPulse needs some macOS permissions to count your stats. &lt;br /&gt;Follow the steps below to make sure WhatPulse will work correctly.</source>
-        <translation type="unfinished"></translation>
+        <translation>WhatPulse 需要一些 macOS 的权限以进行统计。 &lt;br/&gt;按照以下步骤操作以确保 WhatPulse 工作正常。</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="124"/>
         <source>&lt;h2&gt;Accessibility&lt;/h2&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h2&gt;辅助功能&lt;/h2&gt;</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="128"/>
         <source>WhatPulse needs Accessibility permissions to discover applications.</source>
-        <translation type="unfinished"></translation>
+        <translation>WhatPulse 需要辅助功能权限以发现应用。</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="142"/>
         <source>Open Accessibility</source>
-        <translation type="unfinished"></translation>
+        <translation>打开辅助功能</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="169"/>
         <source>&lt;h2&gt;Input Monitoring&lt;/h2&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h2&gt;输入监视&lt;/h2&gt;</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="174"/>
         <source>WhatPulse needs permissions to count your keys and clicks.  Don&apos;t quit WhatPulse when asked.</source>
-        <translation type="unfinished"></translation>
+        <translation>WhatPulse 需要权限以统计你的按键和点击。  当被问到时不要退出 WhatPulse。</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="188"/>
         <source>Open Input Monitoring</source>
-        <translation type="unfinished"></translation>
+        <translation>打开输入监视</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="211"/>
         <source>&lt;center&gt;Here&apos;s how it should look: &lt;br /&gt;&lt;br /&gt;&lt;img src=&quot;:/mac/preferences_example.png&quot; /&gt;&lt;br /&gt;&lt;br /&gt;If the checkbox is already checked,  try unchecking and checking it again.  This can be needed after upgrades.&lt;/center&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;center&gt;它应该长这样： &lt;br/&gt;&lt;br /&gt;&lt;img src=&quot;:/mac/preferences_example.png&quot; /&gt;&lt;br /&gt;&lt;br /&gt;如果这个选项已经勾上了，  尝试取消勾选再重新勾上。  可能升级之后需要这么做。&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../interface/mac/permissionsmanager.cpp" line="217"/>
         <source>&lt;center&gt;All set! WhatPulse has the right permissions.&lt;/center&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;center&gt;可以了！WhatPulse 有权限了。&lt;/center&gt;</translation>
     </message>
 </context>
 <context>
@@ -2837,22 +2860,22 @@ Unpulsed: %2 down, %3 up</source>
     <message>
         <location filename="../resources/progresswindow.ui" line="23"/>
         <source>ProgressWindow</source>
-        <translation type="unfinished"></translation>
+        <translation>ProgressWindow</translation>
     </message>
     <message>
         <location filename="../resources/progresswindow.ui" line="70"/>
         <source>Downloading Update...</source>
-        <translation type="unfinished"></translation>
+        <translation>下载更新中…</translation>
     </message>
     <message>
         <location filename="../resources/progresswindow.ui" line="98"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../interface/widgets/progresswindow.cpp" line="24"/>
         <source>Success!</source>
-        <translation type="unfinished"></translation>
+        <translation>成功！</translation>
     </message>
 </context>
 <context>
@@ -2860,22 +2883,23 @@ Unpulsed: %2 down, %3 up</source>
     <message>
         <location filename="../system/mac/macnativehelpers.mm" line="364"/>
         <source>Accessibility Permissions</source>
-        <translation type="unfinished"></translation>
+        <translation>辅助功能权限</translation>
     </message>
     <message>
         <location filename="../system/mac/macnativehelpers.mm" line="365"/>
         <source>Please allow the client the Accessibility Permission, to allow keyboard &amp; mouse monitoring. Then press OK and WhatPulse will restart. Cancel to exit the client.</source>
-        <translation type="unfinished"></translation>
+        <translation>为了允许客户端监视键盘和鼠标，请允许辅助功能权限。然后按下确定，WhatPulse 将重启。按下取消将退出客户端。</translation>
     </message>
     <message>
         <location filename="../system/mac/macnativehelpers.mm" line="425"/>
         <source>Access for assistive devices</source>
-        <translation type="unfinished"></translation>
+        <translation>辅助功能控制</translation>
     </message>
     <message>
         <location filename="../system/mac/macnativehelpers.mm" line="426"/>
         <source>Mac OS Version not supported; Please tick &quot;Enable access for assistive devices&quot; in the Universal Access pane in System Preferences and restart the client. Keycounting will not work otherwise. An upgraded client requires a re-enable.</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>我手头没有 macOS 设备，不知道人家原话是怎样的</translatorcomment>
+        <translation>Mac OS 版本不支持。请在系统偏好设置中勾选“允许下面的程序控制您的电脑”并重启客户端。否则将无法统计按键。客户端升级将需要重新授权。</translation>
     </message>
 </context>
 <context>
@@ -2883,22 +2907,22 @@ Unpulsed: %2 down, %3 up</source>
     <message>
         <location filename="../3rdparty/quazip/quagzipfile.cpp" line="60"/>
         <source>QIODevice::Append is not supported for GZIP</source>
-        <translation type="unfinished"></translation>
+        <translation>QIODevice::Append 不支持 GZIP</translation>
     </message>
     <message>
         <location filename="../3rdparty/quazip/quagzipfile.cpp" line="66"/>
         <source>Opening gzip for both reading and writing is not supported</source>
-        <translation type="unfinished"></translation>
+        <translation>不支持打开 gzip 以同时读写</translation>
     </message>
     <message>
         <location filename="../3rdparty/quazip/quagzipfile.cpp" line="74"/>
         <source>You can open a gzip either for reading or for writing. Which is it?</source>
-        <translation type="unfinished"></translation>
+        <translation>你可以打开一个 gzip 只读或者只写。用哪个？</translation>
     </message>
     <message>
         <location filename="../3rdparty/quazip/quagzipfile.cpp" line="80"/>
         <source>Could not gzopen() file</source>
-        <translation type="unfinished"></translation>
+        <translation>无法 gzopen() 文件</translation>
     </message>
 </context>
 <context>
@@ -2906,12 +2930,12 @@ Unpulsed: %2 down, %3 up</source>
     <message>
         <location filename="../3rdparty/quazip/quaziodevice.cpp" line="188"/>
         <source>QIODevice::Append is not supported for QuaZIODevice</source>
-        <translation type="unfinished"></translation>
+        <translation>QIODevice::Append 不支持 QuaZIODevice</translation>
     </message>
     <message>
         <location filename="../3rdparty/quazip/quaziodevice.cpp" line="193"/>
         <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
-        <translation type="unfinished"></translation>
+        <translation>QIODevice::ReadWrite 不支持 QuaZIODevice</translation>
     </message>
 </context>
 <context>
@@ -2919,7 +2943,7 @@ Unpulsed: %2 down, %3 up</source>
     <message>
         <location filename="../3rdparty/quazip/quazipfile.cpp" line="251"/>
         <source>ZIP/UNZIP API error %1</source>
-        <translation type="unfinished"></translation>
+        <translation>ZIP/UNZIP API 错误 %1</translation>
     </message>
 </context>
 <context>
@@ -2927,323 +2951,323 @@ Unpulsed: %2 down, %3 up</source>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="113"/>
         <source>General Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>通用设置</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="114"/>
         <source>Automatic Pulsing</source>
-        <translation type="unfinished"></translation>
+        <translation>自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="115"/>
         <source>Geek Window Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>悬浮窗布局</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="117"/>
         <source>Ignored Applications</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略的应用</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="119"/>
         <source>Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>代理</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="120"/>
         <source>Milestones</source>
-        <translation type="unfinished"></translation>
+        <translation>里程碑</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="126"/>
         <source> Check for Updates</source>
-        <translation type="unfinished"></translation>
+        <translation> 检查更新</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="138"/>
         <source> Report Bug</source>
-        <translation type="unfinished"></translation>
+        <translation> 报告缺陷</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="153"/>
         <source> Save</source>
-        <translation type="unfinished"></translation>
+        <translation> 保存</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="186"/>
         <location filename="../interface/SettingsTab.cpp" line="202"/>
         <source>Settings - General</source>
-        <translation type="unfinished"></translation>
+        <translation>设置 - 通用</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="188"/>
         <location filename="../interface/SettingsTab.cpp" line="203"/>
         <source>Settings - Automatic Pulsing</source>
-        <translation type="unfinished"></translation>
+        <translation>设置 - 自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="190"/>
         <location filename="../interface/SettingsTab.cpp" line="204"/>
         <source>Settings - Geek Window Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>设置 - 悬浮窗布局</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="192"/>
         <location filename="../interface/SettingsTab.cpp" line="205"/>
         <source>Settings - Ignored Applications</source>
-        <translation type="unfinished"></translation>
+        <translation>设置 - 忽略的应用</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="194"/>
         <location filename="../interface/SettingsTab.cpp" line="206"/>
         <source>Settings - Proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>设置 - 代理</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="196"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>设置</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="266"/>
         <source>Launch when computer starts</source>
-        <translation type="unfinished"></translation>
+        <translation>计算机启动时启动</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="268"/>
         <source>Enable Portable Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>开启绿色模式</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="270"/>
         <source>Pulse on doubleclick trayicon</source>
-        <translation type="unfinished"></translation>
+        <translation>双击托盘图标时 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="274"/>
         <source>Include beta versions updates</source>
-        <translation type="unfinished"></translation>
+        <translation>检查 Beta 版本更新</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="278"/>
         <source>Blink trayicon on input activity</source>
-        <translation type="unfinished"></translation>
+        <translation>输入时闪烁托盘图标</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="281"/>
         <source>Automatically install new versions</source>
-        <translation type="unfinished"></translation>
+        <translation>自动安装新版本</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="283"/>
         <source>Upload application info</source>
-        <translation type="unfinished"></translation>
+        <translation>上传应用信息</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="286"/>
         <source>Work offline (disables pulsing)</source>
-        <translation type="unfinished"></translation>
+        <translation>脱机工作（禁用 Pulse）</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="289"/>
         <source>Upload heatmap info</source>
-        <translation type="unfinished"></translation>
+        <translation>上传热力图信息</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="292"/>
         <source>Weekly online backups</source>
-        <translation type="unfinished"></translation>
+        <translation>每周线上备份</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="327"/>
         <source>Icon color: </source>
-        <translation type="unfinished"></translation>
+        <translation>图标颜色： </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="331"/>
         <location filename="../interface/SettingsTab.cpp" line="820"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation>自动</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="331"/>
         <location filename="../interface/SettingsTab.cpp" line="822"/>
         <source>Black</source>
-        <translation type="unfinished"></translation>
+        <translation>黑</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="331"/>
         <location filename="../interface/SettingsTab.cpp" line="824"/>
         <source>White</source>
-        <translation type="unfinished"></translation>
+        <translation>白</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="333"/>
         <location filename="../interface/SettingsTab.cpp" line="827"/>
         <source>Development</source>
-        <translation type="unfinished"></translation>
+        <translation>开发</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="348"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>语言： </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="374"/>
         <source>Pulse Server: </source>
-        <translation type="unfinished"></translation>
+        <translation>Pulse 服务器： </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="390"/>
         <source>Active Stats</source>
-        <translation type="unfinished"></translation>
+        <translation>活跃的统计</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="400"/>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation>输入</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="406"/>
         <source>Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="407"/>
         <source>Mouse</source>
-        <translation type="unfinished"></translation>
+        <translation>鼠标</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="408"/>
         <location filename="../interface/SettingsTab.cpp" line="428"/>
         <location filename="../interface/SettingsTab.cpp" line="449"/>
         <source>Per Application</source>
-        <translation type="unfinished"></translation>
+        <translation>分应用</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="418"/>
         <source>Network</source>
-        <translation type="unfinished"></translation>
+        <translation>网络</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="424"/>
         <source>Per Interface</source>
-        <translation type="unfinished"></translation>
+        <translation>分网卡</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="426"/>
         <source>Per Country</source>
-        <translation type="unfinished"></translation>
+        <translation>分国家</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="430"/>
         <source>Per Traffic Type</source>
-        <translation type="unfinished"></translation>
+        <translation>分类型</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="440"/>
         <source>Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="446"/>
         <source>Computer Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>计算机上线时长</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="447"/>
         <source>Reboots</source>
-        <translation type="unfinished"></translation>
+        <translation>重启</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="467"/>
         <source>Advanced</source>
-        <translation type="unfinished"></translation>
+        <translation>高级</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="473"/>
         <source>&amp;Open Data Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>打开数据目录(&amp;O)</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="480"/>
         <source>&amp;Start Online Backup</source>
-        <translation type="unfinished"></translation>
+        <translation>开始线上备份(&amp;S)</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="487"/>
         <source>Re-upload &amp;applications</source>
-        <translation type="unfinished"></translation>
+        <translation>重新上传应用(&amp;A)</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="493"/>
         <source>Empty local &amp;database</source>
-        <translation type="unfinished"></translation>
+        <translation>清空本地数据库(&amp;D)</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="499"/>
         <source>Update &amp;GeoIP database</source>
-        <translation type="unfinished"></translation>
+        <translation>更新地理 IP 数据库(&amp;G)</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="506"/>
         <source>Update Network Port Description database</source>
-        <translation type="unfinished"></translation>
+        <translation>更新网络端口描述数据库</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="513"/>
         <source>&amp;Upload database</source>
-        <translation type="unfinished"></translation>
+        <translation>上传数据库(&amp;U)</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="525"/>
         <source>Check macOS Permissions</source>
-        <translation type="unfinished"></translation>
+        <translation>检查 macOS 权限</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="549"/>
         <source>Uploading applications</source>
-        <translation type="unfinished"></translation>
+        <translation>上传应用</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="576"/>
         <source>Uploading Apps</source>
-        <translation type="unfinished"></translation>
+        <translation>上传应用</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="577"/>
         <source>Applications have been marked for upload. It might take an hour before they appear on the website.</source>
-        <translation type="unfinished"></translation>
+        <translation>应用已标记为上传。到它显示到网站上可能需要一个小时。</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="594"/>
         <source>Empty Database</source>
-        <translation type="unfinished"></translation>
+        <translation>清空数据库</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="595"/>
         <source>Emptying out your local database will destroy all local statistics and logout your account. There is no recovery for this, continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>清空本地数据库将摧毁全部本地统计数据并退出登录。这是无法恢复的，继续？</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="614"/>
         <source>Start Online Backup?</source>
-        <translation type="unfinished"></translation>
+        <translation>开始线上备份？</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="615"/>
         <source>Starting a backup will restart the client and show the backup window. Continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>开始备份将重启客户端并显示备份窗口。继续？</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="773"/>
         <source>Settings saved...</source>
-        <translation type="unfinished"></translation>
+        <translation>设置已保存……</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="812"/>
         <source>Weekly online backups (premium only)</source>
-        <translation type="unfinished"></translation>
+        <translation>每周线上备份（尊享版特权）</translation>
     </message>
 </context>
 <context>
@@ -3255,131 +3279,132 @@ Unpulsed: %2 down, %3 up</source>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="12"/>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="13"/>
         <source>Auto pulse on </source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>拼接了</translatorcomment>
+        <translation>每 </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="14"/>
         <source>Auto pulse on startup</source>
-        <translation type="unfinished"></translation>
+        <translation>启动时自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="80"/>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="87"/>
         <source>Enter a value between 1000 and 99999999</source>
-        <translation type="unfinished"></translation>
+        <translation>输入一个 1000 到 99999999 之间的数字</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="94"/>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="101"/>
         <source>Enter a value between 1024 and 99999999</source>
-        <translation type="unfinished"></translation>
+        <translation>输入一个 1024 到 99999999 之间的数字</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="108"/>
         <source>Enter a value between 1 and 9999</source>
-        <translation type="unfinished"></translation>
+        <translation>输入一个 1 到 9999 之间的数字</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="131"/>
         <source>keys</source>
-        <translation type="unfinished"></translation>
+        <translation>按键自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="136"/>
         <source>clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>点击自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="141"/>
         <source>MB downloaded</source>
-        <translation type="unfinished"></translation>
+        <translation>MB 下载自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="146"/>
         <source>MB uploaded</source>
-        <translation type="unfinished"></translation>
+        <translation>MB 上传自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="151"/>
         <source>hours uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>小时上线时长自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="168"/>
         <source>Auto pulse on hour </source>
-        <translation type="unfinished"></translation>
+        <translation>在何时自动 Pulse </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="172"/>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="456"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>整点</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="179"/>
         <source>every day</source>
-        <translation type="unfinished"></translation>
+        <translation>每天</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="180"/>
         <source>every Monday</source>
-        <translation type="unfinished"></translation>
+        <translation>每周一</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="181"/>
         <source>every Tuesday</source>
-        <translation type="unfinished"></translation>
+        <translation>每周二</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="182"/>
         <source>every Wednesday</source>
-        <translation type="unfinished"></translation>
+        <translation>每周三</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="183"/>
         <source>every Thursday</source>
-        <translation type="unfinished"></translation>
+        <translation>每周四</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="184"/>
         <source>every Friday</source>
-        <translation type="unfinished"></translation>
+        <translation>每周五</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="185"/>
         <source>every Saturday</source>
-        <translation type="unfinished"></translation>
+        <translation>每周六</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="186"/>
         <source>every Sunday</source>
-        <translation type="unfinished"></translation>
+        <translation>每周日</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="371"/>
         <source>WhatPulse will not automatically pulse with your current settings. Change a setting to enable auto pulsing.</source>
-        <translation type="unfinished"></translation>
+        <translation>当前设置无法让 WhatPulse 自动 Pulse。修改一个设置以开启自动 Pulse。</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="374"/>
         <source>WhatPulse will automatically pulse </source>
-        <translation type="unfinished"></translation>
+        <translation>WhatPulse 将</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="386"/>
         <source>when </source>
-        <translation type="unfinished"></translation>
+        <translation>当</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="392"/>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="403"/>
         <source>you reach </source>
-        <translation type="unfinished"></translation>
+        <translation>你达到 </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="395"/>
         <source> keys</source>
-        <translation type="unfinished"></translation>
+        <translation> 按键时自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="401"/>
@@ -3388,47 +3413,47 @@ Unpulsed: %2 down, %3 up</source>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="435"/>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="446"/>
         <source>, &lt;b&gt;or&lt;/b&gt; when </source>
-        <translation type="unfinished"></translation>
+        <translation>，&lt;b&gt;或者&lt;/b&gt;当</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="406"/>
         <source> clicks</source>
-        <translation type="unfinished"></translation>
+        <translation> 点击时自动 Pulse</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="415"/>
         <source>you&apos;ve downloaded </source>
-        <translation type="unfinished"></translation>
+        <translation>每下载 </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="426"/>
         <source>you&apos;ve uploaded </source>
-        <translation type="unfinished"></translation>
+        <translation>每上传 </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="437"/>
         <source>you&apos;ve collected </source>
-        <translation type="unfinished"></translation>
+        <translation>每 </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="440"/>
         <source> hours of uptime</source>
-        <translation type="unfinished"></translation>
+        <translation> 小时上线时长</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="448"/>
         <source>the client starts</source>
-        <translation type="unfinished"></translation>
+        <translation>客户端启动时</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="454"/>
         <source>, &lt;b&gt;and&lt;/b&gt; </source>
-        <translation type="unfinished"></translation>
+        <translation>，&lt;b&gt;以及&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsAutoPulse.cpp" line="457"/>
         <source>every hour on </source>
-        <translation type="unfinished"></translation>
+        <translation>整点</translation>
     </message>
 </context>
 <context>
@@ -3436,7 +3461,7 @@ Unpulsed: %2 down, %3 up</source>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="72"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>添加</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="91"/>
@@ -3444,265 +3469,266 @@ Unpulsed: %2 down, %3 up</source>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="512"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="525"/>
         <source>Select label to edit..</source>
-        <translation type="unfinished"></translation>
+        <translation>选择标签以编辑……</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="108"/>
         <source>Delete label</source>
-        <translation type="unfinished"></translation>
+        <translation>删除标签</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="123"/>
         <source>Insert statistic:</source>
-        <translation type="unfinished"></translation>
+        <translation>插入统计：</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="124"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="429"/>
         <source>Unpulsed Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 按键</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="125"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="431"/>
         <source>Unpulsed Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 点击</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="126"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="433"/>
         <source>Unpulsed Download</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 下载</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="127"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="435"/>
         <source>Unpulsed Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 上传</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="128"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="437"/>
         <source>Unpulsed Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 上线时长</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="129"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="439"/>
         <source>Unpulsed Click Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 点击速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="130"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="441"/>
         <source>Unpulsed Key Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 按键速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="131"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="443"/>
         <source>Unpulsed Download Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 下载速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="132"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="445"/>
         <source>Unpulsed Upload Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 上传速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="133"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="447"/>
         <source>Current Click Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>当前点击速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="134"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="449"/>
         <source>Current Key Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>当前按键速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="135"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="451"/>
         <source>Current Download Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>当前下载速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="136"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="453"/>
         <source>Current Upload Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>当前上传速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="137"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="455"/>
         <source>Total Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>总按键</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="138"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="457"/>
         <source>Total Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>总点击</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="139"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="459"/>
         <source>Total Download</source>
-        <translation type="unfinished"></translation>
+        <translation>总下载</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="140"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="461"/>
         <source>Total Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>总上传</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="141"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="463"/>
         <source>Total Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>总上线时长</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="142"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="465"/>
         <source>Total Click Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>总点击速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="143"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="467"/>
         <source>Total Key Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>总按键速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="144"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="469"/>
         <source>Total Download Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>总下载速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="145"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="471"/>
         <source>Total Upload Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>总上传速度</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="146"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="473"/>
         <source>Rank Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>按键排名</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="147"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="475"/>
         <source>Rank Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>点击排名</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="148"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="477"/>
         <source>Rank Download</source>
-        <translation type="unfinished"></translation>
+        <translation>下载排名</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="149"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="479"/>
         <source>Rank Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>上传排名</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="150"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="481"/>
         <source>Rank Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长排名</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="151"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="483"/>
         <source>Today Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>今日按键</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="152"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="485"/>
         <source>Today Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>今日点击</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="153"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="487"/>
         <source>Today Download</source>
-        <translation type="unfinished"></translation>
+        <translation>今日下载</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="154"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="489"/>
         <source>Today Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>今日上传</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="173"/>
         <source>Snap to grid</source>
-        <translation type="unfinished"></translation>
+        <translation>对齐到网格</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="179"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>重置</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="200"/>
         <source>Call to Center</source>
-        <translation type="unfinished"></translation>
+        <translation>移动到中央</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="256"/>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="264"/>
         <source>Reset to default</source>
-        <translation type="unfinished"></translation>
+        <translation>重置为初始状态</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="268"/>
         <source>Background color: </source>
-        <translation type="unfinished"></translation>
+        <translation>背景颜色： </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="272"/>
         <source>Font color: </source>
-        <translation type="unfinished"></translation>
+        <translation>文字颜色： </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="282"/>
         <source>Font size: </source>
-        <translation type="unfinished"></translation>
+        <translation>文字大小： </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="301"/>
         <source>Transparency: </source>
-        <translation type="unfinished"></translation>
+        <translation>透明度： </translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="320"/>
         <source>Close Geek Window on double click</source>
-        <translation type="unfinished"></translation>
+        <translation>双击关闭悬浮窗</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="326"/>
         <source>Put Geek Window on top</source>
-        <translation type="unfinished"></translation>
+        <translation>悬浮窗置顶</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="594"/>
         <source>Reset to default?</source>
-        <translation type="unfinished"></translation>
+        <translation>重置为初始状态？</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="595"/>
         <source>Do you want to reset the Geek Window to default?
 This will reset any custom layouts!</source>
-        <translation type="unfinished"></translation>
+        <translation>是否将悬浮窗重置为初始状态？
+这将重置全部自定义布局！</translation>
     </message>
 </context>
 <context>
@@ -3710,45 +3736,45 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="15"/>
         <source>Application</source>
-        <translation type="unfinished"></translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="31"/>
         <source>Network interface</source>
-        <translation type="unfinished"></translation>
+        <translation>网卡</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="50"/>
         <source>On this page you can manage applications and network interfaces that you&apos;ve chosen to ignore. Right click an application or interface to manage.</source>
-        <translation type="unfinished"></translation>
+        <translation>本页可以管理你选择忽略的应用和网卡。右键点击一个应用或者网卡。</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="58"/>
         <source>&lt;b&gt;Ignored network interfaces&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;忽略的网卡&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="86"/>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="121"/>
         <source>No applications ignored</source>
-        <translation type="unfinished"></translation>
+        <translation>无忽略应用</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="112"/>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="184"/>
         <source>No network interfaces ignored</source>
-        <translation type="unfinished"></translation>
+        <translation>无忽略网卡</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="126"/>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="189"/>
         <source>Unignore</source>
-        <translation type="unfinished"></translation>
+        <translation>取消忽略</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsIgnoredApps.cpp" line="132"/>
         <source>Open file location</source>
-        <translation type="unfinished"></translation>
+        <translation>打开文件路径</translation>
     </message>
 </context>
 <context>
@@ -3756,114 +3782,114 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="21"/>
         <source>Milestones let you create notifications when you cross certain statistics. Use the &apos;Add&apos; button to create a milestone and doubleclick on the Milestone to edit it.</source>
-        <translation type="unfinished"></translation>
+        <translation>里程碑可以在你达成指定的统计时生成通知。使用“添加”按钮创建一个里程碑，双击里程碑可以进行编辑。</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="27"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation>添加</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="46"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="74"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="307"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名称</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="46"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="75"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="308"/>
         <source>Statistic</source>
-        <translation type="unfinished"></translation>
+        <translation>统计</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="47"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="75"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="308"/>
         <source>Amount</source>
-        <translation type="unfinished"></translation>
+        <translation>数量</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="47"/>
         <source>Actions</source>
-        <translation type="unfinished"></translation>
+        <translation>动作</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="74"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="307"/>
         <source>Time</source>
-        <translation type="unfinished"></translation>
+        <translation>时间</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="87"/>
         <source>&lt;h2&gt;History&lt;/h2&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h2&gt;历史&lt;/h2&gt;</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="164"/>
         <source>Milestone Name</source>
-        <translation type="unfinished"></translation>
+        <translation>里程碑名称</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="170"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="282"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="418"/>
         <source>Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>按键</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="170"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="282"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="420"/>
         <source>Clicks</source>
-        <translation type="unfinished"></translation>
+        <translation>点击</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="170"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="282"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="422"/>
         <source>Downloaded MB</source>
-        <translation type="unfinished"></translation>
+        <translation>下载 MB</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="171"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="283"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="425"/>
         <source>Uploaded MB</source>
-        <translation type="unfinished"></translation>
+        <translation>上传 MB</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="171"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="283"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="428"/>
         <source>Uptime in Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长分钟</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="195"/>
         <source>Delete Milestone</source>
-        <translation type="unfinished"></translation>
+        <translation>删除里程碑</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="196"/>
         <source>Are you sure you want to delete this Milestone?</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除该里程碑？</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="239"/>
         <source>Time for coffee, you&apos;ve made X keys!</source>
-        <translation type="unfinished"></translation>
+        <translation>喝杯咖啡休息一下，你已经按键 X 下了！</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="243"/>
         <source>Milestone Message</source>
-        <translation type="unfinished"></translation>
+        <translation>里程碑信息</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="244"/>
         <source>Display a custom message when this Milestone hits:</source>
-        <translation type="unfinished"></translation>
+        <translation>当里程碑达成时显示自定义信息：</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="395"/>
@@ -3871,12 +3897,12 @@ This will reset any custom layouts!</source>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="403"/>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="407"/>
         <source>Please input 100 or higher.</source>
-        <translation type="unfinished"></translation>
+        <translation>请输入大于等于 100 的数。</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsMilestones.cpp" line="412"/>
         <source>Please input 10 or higher.</source>
-        <translation type="unfinished"></translation>
+        <translation>请输入大于等于 10 的数。</translation>
     </message>
 </context>
 <context>
@@ -3884,103 +3910,103 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="16"/>
         <source>Use manual proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>手动配置代理</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="17"/>
         <source>Auto detect proxy</source>
-        <translation type="unfinished"></translation>
+        <translation>自动检测代理</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="18"/>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="409"/>
         <source> Test proxy</source>
-        <translation type="unfinished"></translation>
+        <translation> 测试代理</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="20"/>
         <source>Proxy authentication required</source>
-        <translation type="unfinished"></translation>
+        <translation>代理需要认证</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="98"/>
         <source>Enable Client API</source>
-        <translation type="unfinished"></translation>
+        <translation>开启客户端 API</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="148"/>
         <source>Hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>服务器：</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="151"/>
         <source>Port:</source>
-        <translation type="unfinished"></translation>
+        <translation>端口：</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="167"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>用户名：</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="170"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>密码：</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="202"/>
         <source>Client API</source>
-        <translation type="unfinished"></translation>
+        <translation>客户端 API</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="209"/>
         <source>The Client API is a way to extract real-time information from the WhatPulse client. You can use this to feed your data into another application. Find out more in our &lt;a href=&quot;http://dev.whatpulse.org&quot;&gt;Developer Center&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>客户端 API 是一种从 WhatPulse 客户端提取实时信息的方式。你可以用它去填充别的应用中的数据。从我们的&lt;a href=&quot;http://dev.whatpulse.org&quot;&gt;开发者中心&lt;/a&gt;寻找更多信息</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="230"/>
         <source>Listen on port:</source>
-        <translation type="unfinished"></translation>
+        <translation>监听端口：</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="236"/>
         <source>Enter a value between 1024 and 65535</source>
-        <translation type="unfinished"></translation>
+        <translation>输入一个 1024 到 65535 之间的数字</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="253"/>
         <source>IPs that are allowed to connect (one per line):</source>
-        <translation type="unfinished"></translation>
+        <translation>允许连接的 IP（一行一个）：</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="371"/>
         <source>Not enough info</source>
-        <translation type="unfinished"></translation>
+        <translation>信息不足</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="372"/>
         <source>Please fill out both the proxy hostname and port number before testing.</source>
-        <translation type="unfinished"></translation>
+        <translation>测试前请填写代理主机和端口号。</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="378"/>
         <source> Testing..</source>
-        <translation type="unfinished"></translation>
+        <translation>测试中…</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="415"/>
         <source>Success!</source>
-        <translation type="unfinished"></translation>
+        <translation>成功！</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="415"/>
         <source>Proxy test worked!</source>
-        <translation type="unfinished"></translation>
+        <translation>代理测试可用！</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="417"/>
         <source>Proxy test error!</source>
-        <translation type="unfinished"></translation>
+        <translation>代理测试错误！</translation>
     </message>
 </context>
 <context>
@@ -3988,57 +4014,57 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="209"/>
         <source>Pulse</source>
-        <translation type="unfinished"></translation>
+        <translation>Pulse</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="215"/>
         <source>Open Client</source>
-        <translation type="unfinished"></translation>
+        <translation>打开客户端</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="221"/>
         <source>View Online Stats</source>
-        <translation type="unfinished"></translation>
+        <translation>查看线上统计</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="227"/>
         <source>Toggle Geek Window</source>
-        <translation type="unfinished"></translation>
+        <translation>显示 / 隐藏悬浮窗</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="234"/>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation>输入</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="240"/>
         <source>Network</source>
-        <translation type="unfinished"></translation>
+        <translation>网络</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="245"/>
         <source>Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="253"/>
         <source>Account</source>
-        <translation type="unfinished"></translation>
+        <translation>帐户</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="259"/>
         <source>Check for Updates</source>
-        <translation type="unfinished"></translation>
+        <translation>检查更新</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="265"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>设置</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="271"/>
         <source>Exit WhatPulse</source>
-        <translation type="unfinished"></translation>
+        <translation>退出 WhatPulse</translation>
     </message>
 </context>
 <context>
@@ -4048,56 +4074,56 @@ This will reset any custom layouts!</source>
         <location filename="../interface/widgets/timeperiod.cpp" line="75"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="210"/>
         <source>real-time</source>
-        <translation type="unfinished"></translation>
+        <translation>实时</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="48"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="77"/>
         <source>today</source>
-        <translation type="unfinished"></translation>
+        <translation>今天</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="52"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="79"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="133"/>
         <source>yesterday</source>
-        <translation type="unfinished"></translation>
+        <translation>昨天</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="56"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="81"/>
         <source>week</source>
-        <translation type="unfinished"></translation>
+        <translation>本周</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="60"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="83"/>
         <source>month</source>
-        <translation type="unfinished"></translation>
+        <translation>本月</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="63"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="85"/>
         <source>6 months</source>
-        <translation type="unfinished"></translation>
+        <translation>最近 6 个月</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="64"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="87"/>
         <source>year</source>
-        <translation type="unfinished"></translation>
+        <translation>今年</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="70"/>
         <source>all</source>
-        <translation type="unfinished"></translation>
+        <translation>全部</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="71"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="89"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="217"/>
         <source>custom</source>
-        <translation type="unfinished"></translation>
+        <translation>自定义</translation>
     </message>
 </context>
 <context>
@@ -4105,22 +4131,22 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="363"/>
         <source>Select the start and end date of the period you&apos;d like to see statistics from.</source>
-        <translation type="unfinished"></translation>
+        <translation>选择你想看的统计周期的时间范围。</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="365"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>保存</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="369"/>
         <source>From:</source>
-        <translation type="unfinished"></translation>
+        <translation>从：</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="381"/>
         <source>To:</source>
-        <translation type="unfinished"></translation>
+        <translation>到：</translation>
     </message>
 </context>
 <context>
@@ -4128,52 +4154,52 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="105"/>
         <source>Keys:</source>
-        <translation type="unfinished"></translation>
+        <translation>按键：</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="106"/>
         <source>Clicks:</source>
-        <translation type="unfinished"></translation>
+        <translation>点击：</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="107"/>
         <source>Uptime:</source>
-        <translation type="unfinished"></translation>
+        <translation>上线：</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="108"/>
         <source>Down:</source>
-        <translation type="unfinished"></translation>
+        <translation>下载：</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="109"/>
         <source>Up:</source>
-        <translation type="unfinished"></translation>
+        <translation>上传：</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="118"/>
         <source>Keys: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>按键： %1</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="123"/>
         <source>Clicks: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>点击： %1</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="129"/>
         <source>Down: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>下载： %1</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="132"/>
         <source>Up: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>上传： %1</translation>
     </message>
     <message>
         <location filename="../interface/tasktraypopup.cpp" line="139"/>
         <source>Uptime: %3</source>
-        <translation type="unfinished"></translation>
+        <translation>上线： %3</translation>
     </message>
 </context>
 <context>
@@ -4181,28 +4207,28 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/UploadDatabaseWindow.cpp" line="45"/>
         <source>Uploading database...</source>
-        <translation type="unfinished"></translation>
+        <translation>上传数据库中…</translation>
     </message>
     <message>
         <location filename="../interface/UploadDatabaseWindow.cpp" line="52"/>
         <location filename="../interface/UploadDatabaseWindow.cpp" line="123"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../interface/UploadDatabaseWindow.cpp" line="63"/>
         <source>Upload database?</source>
-        <translation type="unfinished"></translation>
+        <translation>上传数据库？</translation>
     </message>
     <message>
         <location filename="../interface/UploadDatabaseWindow.cpp" line="63"/>
         <source>Did a developer ask you to upload your database?</source>
-        <translation type="unfinished"></translation>
+        <translation>是否有开发者让你上传你的数据库？</translation>
     </message>
     <message>
         <location filename="../interface/UploadDatabaseWindow.cpp" line="105"/>
         <source> left</source>
-        <translation type="unfinished"></translation>
+        <translation> 剩余</translation>
     </message>
 </context>
 <context>
@@ -4210,47 +4236,47 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1018"/>
         <source>Exporting Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>导出上线时长</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1019"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1025"/>
         <source>Please make your exporting selection below. Select what data you want, then the timespan and whether you want to group it per day, week or month and press Save to export as CSV.</source>
-        <translation type="unfinished"></translation>
+        <translation>请选择你要导出的项目。选择你需要的数据，然后是时间段和你想要的分组，每天、每周或者每月，点击”保存“以导出 CSV 文件。</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1033"/>
         <source>Total uptime per application</source>
-        <translation type="unfinished"></translation>
+        <translation>分应用总上线时间</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1035"/>
         <source>Active time used per application</source>
-        <translation type="unfinished"></translation>
+        <translation>分应用活跃时间</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1036"/>
         <source>List of your reboots</source>
-        <translation type="unfinished"></translation>
+        <translation>重启列表</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1054"/>
         <source>Export from:</source>
-        <translation type="unfinished"></translation>
+        <translation>导出自：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1065"/>
         <source>to:</source>
-        <translation type="unfinished"></translation>
+        <translation>到：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1085"/>
         <source>Group by:</source>
-        <translation type="unfinished"></translation>
+        <translation>分组：</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1088"/>
@@ -4258,79 +4284,79 @@ This will reset any custom layouts!</source>
         <location filename="../interface/ExportWindow.cpp" line="1311"/>
         <location filename="../interface/ExportWindow.cpp" line="1314"/>
         <source>Hour</source>
-        <translation type="unfinished"></translation>
+        <translation>时</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1089"/>
         <source>Day</source>
-        <translation type="unfinished"></translation>
+        <translation>日</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1090"/>
         <location filename="../interface/ExportWindow.cpp" line="1294"/>
         <source>Week</source>
-        <translation type="unfinished"></translation>
+        <translation>周</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1091"/>
         <location filename="../interface/ExportWindow.cpp" line="1298"/>
         <source>Month</source>
-        <translation type="unfinished"></translation>
+        <translation>月</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1101"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>保存</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1109"/>
         <source>Premium Only</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享版独享</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1118"/>
         <source>Working..</source>
-        <translation type="unfinished"></translation>
+        <translation>进行中…</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1142"/>
         <source>You have selected a date range larger than 90 days. Exporting may take a while.</source>
-        <translation type="unfinished"></translation>
+        <translation>你选了一个超过 90 天的时间范围。导出可能需要一会。</translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1212"/>
         <source>Reboot list between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的重启列表 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1242"/>
         <source>Application uptime </source>
-        <translation type="unfinished"></translation>
+        <translation>应用上线时长 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1283"/>
         <source>Active application time between &apos;%1&apos; and &apos;%2&apos; </source>
-        <translation type="unfinished"></translation>
+        <translation>从“%1”到“%2”的应用活跃时间 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1291"/>
         <source>grouped by Hour </source>
-        <translation type="unfinished"></translation>
+        <translation>按小时分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1295"/>
         <source>grouped by Week </source>
-        <translation type="unfinished"></translation>
+        <translation>按周分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1299"/>
         <source>grouped by Month </source>
-        <translation type="unfinished"></translation>
+        <translation>按月分组 </translation>
     </message>
     <message>
         <location filename="../interface/ExportWindow.cpp" line="1303"/>
         <source>grouped by Day </source>
-        <translation type="unfinished"></translation>
+        <translation>按天分组 </translation>
     </message>
 </context>
 <context>
@@ -4338,129 +4364,129 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="50"/>
         <source>Computer Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>计算机上线时长</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="52"/>
         <source>Reboot Calendar</source>
-        <translation type="unfinished"></translation>
+        <translation>重启日历</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="54"/>
         <source>Applications</source>
-        <translation type="unfinished"></translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="56"/>
         <source>Application Activity</source>
-        <translation type="unfinished"></translation>
+        <translation>应用活动</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="70"/>
         <source> Reset</source>
-        <translation type="unfinished"></translation>
+        <translation> 重置</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="84"/>
         <location filename="../interface/UptimeTab.cpp" line="98"/>
         <source>Uptime - Computer Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长 - 计算机上线时长</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="86"/>
         <location filename="../interface/UptimeTab.cpp" line="99"/>
         <source>Uptime - Reboot Calendar</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长 - 重启日历</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="88"/>
         <location filename="../interface/UptimeTab.cpp" line="100"/>
         <source>Uptime - Applications</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长 - 应用</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="90"/>
         <location filename="../interface/UptimeTab.cpp" line="101"/>
         <source>Uptime - Application Activity</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长 - 应用活动</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="92"/>
         <source>Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>上线时长</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="140"/>
         <location filename="../interface/UptimeTab.cpp" line="271"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>导出</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="152"/>
         <location filename="../interface/UptimeTab.cpp" line="283"/>
         <source>&amp;Export to .csv</source>
-        <translation type="unfinished"></translation>
+        <translation>导出为 CSV 格式(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="156"/>
         <location filename="../interface/UptimeTab.cpp" line="286"/>
         <source>&amp;Export Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="186"/>
         <source>Go Premium</source>
-        <translation type="unfinished"></translation>
+        <translation>开始尊享版</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="205"/>
         <source>&lt;h3&gt;Favorite reboot days&lt;/h3&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;h3&gt;重启日之最&lt;/h3&gt;</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="231"/>
         <source>Sun</source>
-        <translation type="unfinished"></translation>
+        <translation>日</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="231"/>
         <source>Mon</source>
-        <translation type="unfinished"></translation>
+        <translation>一</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="231"/>
         <source>Tue</source>
-        <translation type="unfinished"></translation>
+        <translation>二</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="231"/>
         <source>Wed</source>
-        <translation type="unfinished"></translation>
+        <translation>三</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="232"/>
         <source>Thu</source>
-        <translation type="unfinished"></translation>
+        <translation>四</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="232"/>
         <source>Fri</source>
-        <translation type="unfinished"></translation>
+        <translation>五</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="232"/>
         <source>Sat</source>
-        <translation type="unfinished"></translation>
+        <translation>六</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="247"/>
         <source>Show only recently used applications</source>
-        <translation type="unfinished"></translation>
+        <translation>仅显示最近使用的应用</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="254"/>
         <source>Show only running applications</source>
-        <translation type="unfinished"></translation>
+        <translation>仅显示运行着的应用</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="305"/>
@@ -4470,141 +4496,141 @@ This will reset any custom layouts!</source>
         <location filename="../interface/UptimeTab.cpp" line="309"/>
         <location filename="../interface/UptimeTab.cpp" line="310"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="321"/>
         <source>Unpulsed uptime:</source>
-        <translation type="unfinished"></translation>
+        <translation>未 Pulse 上线时长：</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="324"/>
         <source>Current uptime:</source>
-        <translation type="unfinished"></translation>
+        <translation>当前上线时长：</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="327"/>
         <source>Total uptime:</source>
-        <translation type="unfinished"></translation>
+        <translation>总上线时长：</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="330"/>
         <source>Longest uptime:</source>
-        <translation type="unfinished"></translation>
+        <translation>最长上线时长：</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="333"/>
         <source>Average uptime:</source>
-        <translation type="unfinished"></translation>
+        <translation>平均上线时长：</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="336"/>
         <source>Total reboots:</source>
-        <translation type="unfinished"></translation>
+        <translation>总重启次数：</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="346"/>
         <source>Reboot history for </source>
-        <translation type="unfinished"></translation>
+        <translation>重启于 </translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="391"/>
         <source>No reboots found</source>
-        <translation type="unfinished"></translation>
+        <translation>当天没有重启</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="404"/>
         <source>Reboot history</source>
-        <translation type="unfinished"></translation>
+        <translation>重启历史</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="463"/>
         <source>Application</source>
-        <translation type="unfinished"></translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="463"/>
         <source>Total time</source>
-        <translation type="unfinished"></translation>
+        <translation>总时间</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="464"/>
         <source>Total active time</source>
-        <translation type="unfinished"></translation>
+        <translation>总活跃时间</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="491"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="497"/>
         <source>Open File Location</source>
-        <translation type="unfinished"></translation>
+        <translation>打开文件路径</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="503"/>
         <source>Open Online Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>打开线上个人页</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="518"/>
         <source>Ignore application?</source>
-        <translation type="unfinished"></translation>
+        <translation>忽略应用？</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="519"/>
         <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定忽略应用”%1“？这将同时移除该应用的历史。</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="570"/>
         <source>Not yet</source>
-        <translation type="unfinished"></translation>
+        <translation>先不要</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="571"/>
         <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
-        <translation type="unfinished"></translation>
+        <translation>该应用尚未上传到网站，请一小时左右之后再试。</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="908"/>
         <location filename="../interface/UptimeTab.cpp" line="914"/>
         <source>uptime and reboot data (all except per application) </source>
-        <translation type="unfinished"></translation>
+        <translation>上线和重启数据（除分应用之外） </translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="909"/>
         <location filename="../interface/UptimeTab.cpp" line="915"/>
         <source>Reset Uptime/Reboot History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置上线时间 / 重启历史</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="919"/>
         <location filename="../interface/UptimeTab.cpp" line="924"/>
         <source>application uptime data</source>
-        <translation type="unfinished"></translation>
+        <translation>应用上线时长数据</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="920"/>
         <location filename="../interface/UptimeTab.cpp" line="925"/>
         <source>Reset Application History</source>
-        <translation type="unfinished"></translation>
+        <translation>重置应用历史</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="929"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>取消</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="931"/>
         <source>Do you want to reset all uptime data or just the %1?</source>
-        <translation type="unfinished"></translation>
+        <translation>你是准备重置全部上线时长数据还是说只是%1？</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="934"/>
         <source>Reset All Data</source>
-        <translation type="unfinished"></translation>
+        <translation>重置全部数据</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="949"/>
@@ -4614,29 +4640,29 @@ This will reset any custom layouts!</source>
         <location filename="../interface/UptimeTab.cpp" line="1008"/>
         <location filename="../interface/UptimeTab.cpp" line="1025"/>
         <source>Delete stats?</source>
-        <translation type="unfinished"></translation>
+        <translation>删除统计？</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="950"/>
         <location filename="../interface/UptimeTab.cpp" line="968"/>
         <source>Are you sure you want to delete all (except per application) recorded uptime statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部上线时长数据记录（除分应用之外）？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="986"/>
         <location filename="../interface/UptimeTab.cpp" line="1009"/>
         <source>Are you sure you want to delete all recorded per application uptime statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部分应用上线时长数据记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="1001"/>
         <source>Are you sure you want to delete all recorded keyboard and mouse statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部键盘与鼠标统计记录？该操作无法撤销。</translation>
     </message>
     <message>
         <location filename="../interface/UptimeTab.cpp" line="1026"/>
         <source>Are you sure you want to delete all recorded uptime statistics? This cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>确定删除全部上线时长统计记录？该操作无法撤销。</translation>
     </message>
 </context>
 <context>
@@ -4644,255 +4670,255 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../utils.cpp" line="74"/>
         <source>&lt;1 min</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;1 分</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="74"/>
         <source>Less than a minute</source>
-        <translation type="unfinished"></translation>
+        <translation>小于一分钟</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="81"/>
         <source>1 year</source>
-        <translation type="unfinished"></translation>
+        <translation>1 年</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="83"/>
         <source>%1 years</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 年</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="89"/>
         <source>1 day</source>
-        <translation type="unfinished"></translation>
+        <translation>1 天</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="91"/>
         <source>%1 days</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 天</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="97"/>
         <source>1 hour</source>
-        <translation type="unfinished"></translation>
+        <translation>1 小时</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="99"/>
         <source>%1 hours</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 小时</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="106"/>
         <source>1 min</source>
-        <translation type="unfinished"></translation>
+        <translation>1 分</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="108"/>
         <source>1 minute</source>
-        <translation type="unfinished"></translation>
+        <translation>1 分钟</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="111"/>
         <source>%1 min</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 分</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="113"/>
         <source>%1 minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 分钟</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="376"/>
         <source>th</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="379"/>
         <source>st</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="381"/>
         <source>nd</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="383"/>
         <source>rd</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="472"/>
         <source>Sunday</source>
-        <translation type="unfinished"></translation>
+        <translation>周日</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="474"/>
         <source>Monday</source>
-        <translation type="unfinished"></translation>
+        <translation>周一</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="476"/>
         <source>Tuesday</source>
-        <translation type="unfinished"></translation>
+        <translation>周二</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="478"/>
         <source>Wednesday</source>
-        <translation type="unfinished"></translation>
+        <translation>周三</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="480"/>
         <source>Thursday</source>
-        <translation type="unfinished"></translation>
+        <translation>周四</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="482"/>
         <source>Friday</source>
-        <translation type="unfinished"></translation>
+        <translation>周五</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="484"/>
         <source>Saturday</source>
-        <translation type="unfinished"></translation>
+        <translation>周六</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="982"/>
         <location filename="../utils.cpp" line="1008"/>
         <source>Save as...</source>
-        <translation type="unfinished"></translation>
+        <translation>另存为…</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="995"/>
         <location filename="../utils.cpp" line="1023"/>
         <source>Export Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>导出失败</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="996"/>
         <location filename="../utils.cpp" line="1024"/>
         <source>Opening export file failed! Please try again in another directory.</source>
-        <translation type="unfinished"></translation>
+        <translation>打开导出文件失败！请使用其他目录重试。</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1034"/>
         <source>Backspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Backspace</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1037"/>
         <source>Enter</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1040"/>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Tab</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1043"/>
         <source>Capslock</source>
-        <translation type="unfinished"></translation>
+        <translation>Capslock</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1046"/>
         <source>Left Shift</source>
-        <translation type="unfinished"></translation>
+        <translation>左 Shift</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1049"/>
         <source>Left Control</source>
-        <translation type="unfinished"></translation>
+        <translation>左 Control</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1052"/>
         <source>Left Alt</source>
-        <translation type="unfinished"></translation>
+        <translation>左 Alt</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1055"/>
         <source>Right Alt</source>
-        <translation type="unfinished"></translation>
+        <translation>右 Alt</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1058"/>
         <source>Right Control</source>
-        <translation type="unfinished"></translation>
+        <translation>右 Control</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1061"/>
         <source>Right Shift</source>
-        <translation type="unfinished"></translation>
+        <translation>右 Shift</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1064"/>
         <source>Left</source>
-        <translation type="unfinished"></translation>
+        <translation>左</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1067"/>
         <source>Down</source>
-        <translation type="unfinished"></translation>
+        <translation>下</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1070"/>
         <source>Right</source>
-        <translation type="unfinished"></translation>
+        <translation>右</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1073"/>
         <source>Up</source>
-        <translation type="unfinished"></translation>
+        <translation>上</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1076"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation>Insert</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1079"/>
         <source>Home</source>
-        <translation type="unfinished"></translation>
+        <translation>Home</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1082"/>
         <source>Page Up</source>
-        <translation type="unfinished"></translation>
+        <translation>Page Up</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1085"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1088"/>
         <source>End</source>
-        <translation type="unfinished"></translation>
+        <translation>End</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1091"/>
         <source>Page Down</source>
-        <translation type="unfinished"></translation>
+        <translation>Page Down</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1094"/>
         <source>Escape</source>
-        <translation type="unfinished"></translation>
+        <translation>Esc</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1136"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation>Space</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1253"/>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
     <message>
         <location filename="../utils.cpp" line="1391"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>未知</translation>
     </message>
 </context>
 <context>
@@ -4901,12 +4927,12 @@ This will reset any custom layouts!</source>
         <location filename="../online/whttp.cpp" line="129"/>
         <location filename="../online/whttp.cpp" line="371"/>
         <source>SSL errors, something fishy is going on!</source>
-        <translation type="unfinished"></translation>
+        <translation>SSL 错误，有人钓鱼！</translation>
     </message>
     <message>
         <location filename="../online/whttp.cpp" line="529"/>
         <source>SSL Connection to website failed! This could be our fault, but it could also be a proxy trying to peek into our communication. Please disable the proxy, if that&apos;s the case.</source>
-        <translation type="unfinished"></translation>
+        <translation>到网站的 SSL 连接失败！这可能是我们的锅，但也可能是一个正在窥探我们对话的代理。如果是那样的话，请关闭代理。</translation>
     </message>
 </context>
 <context>
@@ -4914,32 +4940,32 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../online/whttpserver_responder.cpp" line="23"/>
         <source>Execute a pulse</source>
-        <translation type="unfinished"></translation>
+        <translation>执行一个 Pulse</translation>
     </message>
     <message>
         <location filename="../online/whttpserver_responder.cpp" line="28"/>
         <source>Index of all possible calls</source>
-        <translation type="unfinished"></translation>
+        <translation>全部可能的调用列表</translation>
     </message>
     <message>
         <location filename="../online/whttpserver_responder.cpp" line="33"/>
         <source>Get all unpulsed stats</source>
-        <translation type="unfinished"></translation>
+        <translation>获取全部未 Pulse 的统计</translation>
     </message>
     <message>
         <location filename="../online/whttpserver_responder.cpp" line="38"/>
         <source>Get all total account stats</source>
-        <translation type="unfinished"></translation>
+        <translation>获取全部帐户统计</translation>
     </message>
     <message>
         <location filename="../online/whttpserver_responder.cpp" line="44"/>
         <source>Get real-time information (keys per second, current download, etc)</source>
-        <translation type="unfinished"></translation>
+        <translation>获取实时信息（每秒按键，当前下载，等等）</translation>
     </message>
     <message>
         <location filename="../online/whttpserver_responder.cpp" line="101"/>
         <source>{ &quot;error&quot;: &quot;Unable to parse information.&quot;}</source>
-        <translation type="unfinished"></translation>
+        <translation>{ &quot;error&quot;: &quot;无法解析信息。&quot;}</translation>
     </message>
 </context>
 <context>
@@ -4947,49 +4973,49 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="21"/>
         <source>You have been redirected to the website, please follow the instructions there. After you finish the login procedure, the client will automagically log in and you&apos;re off to the races!</source>
-        <translation type="unfinished"></translation>
+        <translation>请按照重定向到的网站上的指示操作。在你完成登录流程后，客户端将自动登录，然后你就进入赛道了！</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="38"/>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="80"/>
         <source>Waiting on authorization via website..</source>
-        <translation type="unfinished"></translation>
+        <translation>等待网站认证中……</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="130"/>
         <source>If your browser did not open, try clicking or copying &lt;a href=&quot;%1&quot;&gt;this link&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>如果浏览器未打开的话，试试看点击或者复制&lt;a href=&quot;%1&quot;&gt;这个链接&lt;/a&gt;。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="149"/>
         <source>Our server is currently in maintenance, please check back in a few minutes. Sorry!</source>
-        <translation type="unfinished"></translation>
+        <translation>我们的服务器在维护中，请过一会再来。抱歉！</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="162"/>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="175"/>
         <source>Our server producing errors, please check back in a few minutes. Sorry!</source>
-        <translation type="unfinished"></translation>
+        <translation>我们的服务器出现了错误，请过一会再来。抱歉！</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="320"/>
         <source>Restore Database?</source>
-        <translation type="unfinished"></translation>
+        <translation>恢复数据库？</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="321"/>
         <source>Good news! I found your previous client database backups, do you want to restore?</source>
-        <translation type="unfinished"></translation>
+        <translation>好消息！我发现了以前的客户端数据库的备份，要恢复吗？</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="330"/>
         <source>Restore Settings?</source>
-        <translation type="unfinished"></translation>
+        <translation>恢复设置？</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardAuthorizationPage.cpp" line="331"/>
         <source>Good news! I found your previous client settings, do you want to load them?</source>
-        <translation type="unfinished"></translation>
+        <translation>好消息！我发现了以前的客户端设置，要加载它吗？</translation>
     </message>
 </context>
 <context>
@@ -4997,17 +5023,17 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/AccountTabWizard/WizardMainPage.cpp" line="11"/>
         <source>Welcome to WhatPulse, &lt;b&gt;the only&lt;/b&gt; statistics program you&apos;ll ever need. WhatPulse answers the question &apos;How much do I use my computer in one day?&apos;&lt;br /&gt;&lt;br /&gt;Let&apos;s get started. If you already have an account, please click &lt;b&gt;Login&lt;/b&gt;. If you are new to WhatPulse, please click &lt;b&gt;Register&lt;/b&gt;.&lt;br /&gt;&lt;br /&gt;In both cases you&apos;ll be redirected to our website to complete the login.&lt;br /&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>欢迎来到 WhatPulse，你&lt;b&gt;唯一&lt;/b&gt;需要的统计程序。WhatPulse 的目的是回答“我每天使用电脑的程度如何？”这个问题。&lt;br /&gt;&lt;br /&gt;让我们开始吧。如果你已经有一个帐户，请直接&lt;b&gt;登录&lt;/b&gt;。如果你以前没有使用过 WhatPulse，请点击&lt;b&gt;注册&lt;/b&gt;。&lt;br /&gt;&lt;br /&gt;你将会被重定向到我们的网站以登录。&lt;br /&gt;</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardMainPage.cpp" line="25"/>
         <source>Login</source>
-        <translation type="unfinished"></translation>
+        <translation>登录</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardMainPage.cpp" line="27"/>
         <source>Register Account</source>
-        <translation type="unfinished"></translation>
+        <translation>注册</translation>
     </message>
 </context>
 <context>
@@ -5015,99 +5041,99 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="72"/>
         <source>Date</source>
-        <translation type="unfinished"></translation>
+        <translation>日期</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="72"/>
         <source>Computer</source>
-        <translation type="unfinished"></translation>
+        <translation>计算机</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="73"/>
         <source>Backup Size</source>
-        <translation type="unfinished"></translation>
+        <translation>备份大小</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="106"/>
         <source>Almost there! Select a database from the list below and click Finish to download and restore.</source>
-        <translation type="unfinished"></translation>
+        <translation>快好了！从下边的列表里选择一个数据库并点击完成以下载并恢复。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="109"/>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation>下载</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="112"/>
         <source>Almost there! Click Finish to apply your previous client settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>快好了！点击完成以应用以前的客户端设置。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="162"/>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="170"/>
         <source>Cannot proceed</source>
-        <translation type="unfinished"></translation>
+        <translation>无法继续</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="163"/>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="171"/>
         <source>Please select a database backup file from the list before you proceed.</source>
-        <translation type="unfinished"></translation>
+        <translation>继续下一步之前，请从列表中选择一个数据库备份文件。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="190"/>
         <source>Contacting website..</source>
-        <translation type="unfinished"></translation>
+        <translation>联系网站中…</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="398"/>
         <source>Starting download..</source>
-        <translation type="unfinished"></translation>
+        <translation>开始下载…</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="401"/>
         <source>Premium only</source>
-        <translation type="unfinished"></translation>
+        <translation>尊享版独享</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="402"/>
         <source>Sorry, the online backup feature is for Premium members only. There&apos;s more information here: https://whatpulse.org/premium</source>
-        <translation type="unfinished"></translation>
+        <translation>抱歉，在线备份功能仅面向尊享版。更多信息：https://whatpulse.org/premium</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="407"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>错误</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="408"/>
         <source>Sorry, the website gave an error preparing for your backup. Please try again later. Here&apos;s the error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>抱歉，准备你的备份时网站出错。请稍后再试。错误是： %1</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="423"/>
         <source>Downloading backup..</source>
-        <translation type="unfinished"></translation>
+        <translation>下载备份中…</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="431"/>
         <source>Download completed!</source>
-        <translation type="unfinished"></translation>
+        <translation>下载完成！</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="439"/>
         <source>Extracting database..</source>
-        <translation type="unfinished"></translation>
+        <translation>解压数据库中…</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="460"/>
         <source>All done! Please restart the client by clicking Finished.</source>
-        <translation type="unfinished"></translation>
+        <translation>可以啦！请点击完成以重启客户端。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardRestoreSettingsPage.cpp" line="462"/>
         <source>Finished</source>
-        <translation type="unfinished"></translation>
+        <translation>完成</translation>
     </message>
 </context>
 <context>
@@ -5115,62 +5141,62 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="24"/>
         <source>Almost there! Set up the most important settings here. Click an option to see more detail.</source>
-        <translation type="unfinished"></translation>
+        <translation>快好了！这里是最重要的设置。点击任意选项查看详情。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="59"/>
         <source>1. Measure your Keyboard &amp; Mouse</source>
-        <translation type="unfinished"></translation>
+        <translation>1. 统计你的键盘和鼠标</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="67"/>
         <source>When this option is enabled, WhatPulse will count your keystrokes and mouse clicks. It counts the times a specific key of button has been pressed.</source>
-        <translation type="unfinished"></translation>
+        <translation>开启该选项将令 WhatPulse 统计你的键盘按键和鼠标点击次数。它统计特定的按键被按下的次数。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="76"/>
         <source>Also send to the website for use in your Dashboard.</source>
-        <translation type="unfinished"></translation>
+        <translation>并将数据发送到网站以显示在你的仪表盘上。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="87"/>
         <source>2. Measure Network Traffic</source>
-        <translation type="unfinished"></translation>
+        <translation>2. 统计网络流量</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="95"/>
         <source>This option has WhatPulse look at your networking traffic and measure the bytes of data going through your computer.</source>
-        <translation type="unfinished"></translation>
+        <translation>该选项将令 WhatPulse 查看你的网络流量并统计流经你计算机的数据字节数。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="109"/>
         <source>3. Measure Computer Uptime</source>
-        <translation type="unfinished"></translation>
+        <translation>3. 统计计算机上线时长</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="117"/>
         <source>Ever wondered how long your computer is turned on? This option will tell you just that. As a part of uptime, this will also tell you how long you&apos;re using specific applications.</source>
-        <translation type="unfinished"></translation>
+        <translation>好奇你计算机开了多久？该选项将告诉你这个问题。作为上线时长的一部分，该选项同时告诉你指定应用的使用时长。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="129"/>
         <source>4. Measure Application Usage</source>
-        <translation type="unfinished"></translation>
+        <translation>4. 统计应用使用情况</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="137"/>
         <source>What apps do you use the most? Which apps download the most? This will provide you with insight.</source>
-        <translation type="unfinished"></translation>
+        <translation>哪个应用使用最多？哪个应用下载最多？该选项将告诉你答案。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="145"/>
         <source>Also send online for your Dashboard &amp; Apps Overview.</source>
-        <translation type="unfinished"></translation>
+        <translation>并将数据发送以显示在你的仪表盘和应用概览上。</translation>
     </message>
     <message>
         <location filename="../interface/AccountTabWizard/WizardSettingsPage.cpp" line="159"/>
         <source>&lt;small&gt;If you want to collect all stats, but not show them publicly, check out your &lt;a href=&quot;https://whatpulse.org/dashboard/my/privacy&quot;&gt;privacy settings&lt;/a&gt;.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;small&gt;如果你想统计全部信息，但是不想公开，请检查&lt;a href=&quot;https://whatpulse.org/dashboard/my/privacy&quot;&gt;隐私设置&lt;/a&gt;。</translation>
     </message>
 </context>
 </TS>

--- a/whatpulse_zh_CN.ts
+++ b/whatpulse_zh_CN.ts
@@ -62,118 +62,118 @@
         <translation>总上线：</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="132"/>
+        <location filename="../interface/AccountTab.cpp" line="133"/>
         <source> &amp;View Online Stats</source>
         <translation> 查看线上统计(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="140"/>
+        <location filename="../interface/AccountTab.cpp" line="141"/>
         <source> &amp;Log out</source>
         <translation> 退出(&amp;L)</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="148"/>
+        <location filename="../interface/AccountTab.cpp" line="147"/>
         <source> &amp;Reset Token</source>
         <translation> 重置(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="156"/>
+        <location filename="../interface/AccountTab.cpp" line="154"/>
         <source> Change &amp;Password</source>
         <translation> 修改密码(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="165"/>
+        <location filename="../interface/AccountTab.cpp" line="162"/>
         <source> Refresh &amp;Account</source>
         <translation> 刷新帐户(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="219"/>
-        <location filename="../interface/AccountTab.cpp" line="225"/>
-        <location filename="../interface/AccountTab.cpp" line="231"/>
-        <location filename="../interface/AccountTab.cpp" line="237"/>
-        <location filename="../interface/AccountTab.cpp" line="243"/>
+        <location filename="../interface/AccountTab.cpp" line="214"/>
+        <location filename="../interface/AccountTab.cpp" line="220"/>
+        <location filename="../interface/AccountTab.cpp" line="226"/>
+        <location filename="../interface/AccountTab.cpp" line="232"/>
+        <location filename="../interface/AccountTab.cpp" line="238"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="247"/>
+        <location filename="../interface/AccountTab.cpp" line="242"/>
         <source>Yes (expires at %1)</source>
         <translation>是（截至 %1）</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="251"/>
-        <location filename="../interface/AccountTab.cpp" line="317"/>
-        <location filename="../interface/AccountTab.cpp" line="347"/>
+        <location filename="../interface/AccountTab.cpp" line="246"/>
+        <location filename="../interface/AccountTab.cpp" line="312"/>
+        <location filename="../interface/AccountTab.cpp" line="342"/>
         <source>No</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="310"/>
+        <location filename="../interface/AccountTab.cpp" line="305"/>
         <source>Log Out</source>
         <translation>登出</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="312"/>
+        <location filename="../interface/AccountTab.cpp" line="307"/>
         <source>Logging out of your account will reset your unpulsed statistics if you login to a different account (database is preserved) and restart the Setup Assistant.</source>
         <translation>如果你退出登录并使用不同的帐户重新登录的话，那么未 Pulse 的统计将被重置（但是数据库会保留），并将重新启动设置向导。</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="316"/>
+        <location filename="../interface/AccountTab.cpp" line="311"/>
         <source>Do you want to continue?</source>
         <translation>是否继续？</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="317"/>
+        <location filename="../interface/AccountTab.cpp" line="312"/>
         <source>Yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="332"/>
+        <location filename="../interface/AccountTab.cpp" line="327"/>
         <source>Change Password</source>
         <translation>修改密码</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="333"/>
+        <location filename="../interface/AccountTab.cpp" line="328"/>
         <source>You can&apos;t change your password inside the client. Please log out and log back in with the same email address and computer name to change your password in this client. Your stats will be preserved if you use the same details.</source>
         <translation>无法在客户端里修改密码。请退出登录，然后使用相同的邮箱和计算机名重新登录以在客户端里修改密码。使用相同的信息时统计会保留。</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="338"/>
-        <location filename="../interface/AccountTab.cpp" line="377"/>
-        <location filename="../interface/AccountTab.cpp" line="383"/>
-        <location filename="../interface/AccountTab.cpp" line="450"/>
+        <location filename="../interface/AccountTab.cpp" line="333"/>
+        <location filename="../interface/AccountTab.cpp" line="372"/>
+        <location filename="../interface/AccountTab.cpp" line="378"/>
+        <location filename="../interface/AccountTab.cpp" line="445"/>
         <source>OK</source>
         <translation>好的</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="343"/>
-        <location filename="../interface/AccountTab.cpp" line="380"/>
+        <location filename="../interface/AccountTab.cpp" line="338"/>
+        <location filename="../interface/AccountTab.cpp" line="375"/>
         <source>Reset your token</source>
         <translation>重置令牌</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="344"/>
+        <location filename="../interface/AccountTab.cpp" line="339"/>
         <source>Resetting your token will reset your local statistics and allow you to pulse again.</source>
         <translatorcomment>Pulse 保留不翻译了吧</translatorcomment>
         <translation>重置令牌将重置你的本地统计，并允许你重新 Pulse。</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="346"/>
+        <location filename="../interface/AccountTab.cpp" line="341"/>
         <source>Are you sure?</source>
         <translation>确定？</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="347"/>
+        <location filename="../interface/AccountTab.cpp" line="342"/>
         <source>Yes, reset token</source>
         <translation>确定，重置令牌</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="375"/>
+        <location filename="../interface/AccountTab.cpp" line="370"/>
         <source>Token reset!</source>
         <translation>令牌已重置！</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="376"/>
+        <location filename="../interface/AccountTab.cpp" line="371"/>
         <source>Token reset!
 
 You can continue pulsing.</source>
@@ -182,27 +182,27 @@ You can continue pulsing.</source>
 你可以重新 Pulse 了。</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="381"/>
+        <location filename="../interface/AccountTab.cpp" line="376"/>
         <source>Something went wrong while resetting your token:</source>
         <translation>重置令牌时出错：</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="440"/>
+        <location filename="../interface/AccountTab.cpp" line="435"/>
         <source>Premium Membership</source>
         <translation>尊享版会员</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="441"/>
+        <location filename="../interface/AccountTab.cpp" line="436"/>
         <source>Your premium membership has just been activated!</source>
         <translation>你的尊享版会员已激活！</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="447"/>
+        <location filename="../interface/AccountTab.cpp" line="442"/>
         <source>Refresh Account Status</source>
         <translation>刷新帐户状态</translation>
     </message>
     <message>
-        <location filename="../interface/AccountTab.cpp" line="448"/>
+        <location filename="../interface/AccountTab.cpp" line="443"/>
         <source>Something went wrong while refreshing your account data:</source>
         <translation>刷新帐户数据时出错：</translation>
     </message>
@@ -1030,534 +1030,526 @@ Please check your permissions on: %2</source>
 <context>
     <name>InputTab</name>
     <message>
-        <location filename="../interface/InputTab.cpp" line="71"/>
-        <location filename="../interface/InputTab.cpp" line="73"/>
-        <location filename="../interface/InputTab.cpp" line="75"/>
-        <location filename="../interface/InputTab.cpp" line="77"/>
-        <location filename="../interface/InputTab.cpp" line="1141"/>
-        <location filename="../interface/InputTab.cpp" line="1151"/>
-        <location filename="../interface/InputTab.cpp" line="1161"/>
+        <location filename="../interface/InputTab.cpp" line="1107"/>
+        <location filename="../interface/InputTab.cpp" line="1117"/>
+        <location filename="../interface/InputTab.cpp" line="1127"/>
         <source>Keys:</source>
         <translation>按键：</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="72"/>
-        <location filename="../interface/InputTab.cpp" line="74"/>
-        <location filename="../interface/InputTab.cpp" line="76"/>
-        <location filename="../interface/InputTab.cpp" line="78"/>
-        <location filename="../interface/InputTab.cpp" line="1142"/>
-        <location filename="../interface/InputTab.cpp" line="1152"/>
-        <location filename="../interface/InputTab.cpp" line="1162"/>
+        <location filename="../interface/InputTab.cpp" line="1108"/>
+        <location filename="../interface/InputTab.cpp" line="1118"/>
+        <location filename="../interface/InputTab.cpp" line="1128"/>
         <source>Clicks:</source>
         <translation>点击：</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="99"/>
+        <location filename="../interface/InputTab.cpp" line="90"/>
         <source>Keyboard Heatmap</source>
         <translation>键盘热力图</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="100"/>
+        <location filename="../interface/InputTab.cpp" line="91"/>
         <source>Mouse Heatmap</source>
         <translation>鼠标热力图</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="101"/>
+        <location filename="../interface/InputTab.cpp" line="92"/>
         <source>Applications</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="102"/>
+        <location filename="../interface/InputTab.cpp" line="93"/>
         <source>Input History</source>
         <translation>输入历史</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="104"/>
+        <location filename="../interface/InputTab.cpp" line="95"/>
         <source>Key Combinations</source>
         <translatorcomment>按键组合？</translatorcomment>
         <translation>组合键</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="125"/>
+        <location filename="../interface/InputTab.cpp" line="116"/>
         <source> Reset</source>
         <translation> 重置</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="191"/>
+        <location filename="../interface/InputTab.cpp" line="182"/>
         <source>Combination</source>
         <translation>组合</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="191"/>
+        <location filename="../interface/InputTab.cpp" line="182"/>
         <source>Used</source>
         <translation>使用次数</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="208"/>
+        <location filename="../interface/InputTab.cpp" line="199"/>
         <source>Hide Shift only</source>
         <translation>隐藏纯 Shift</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="217"/>
+        <location filename="../interface/InputTab.cpp" line="208"/>
         <source>Hide Ctrl only</source>
         <translation>隐藏纯 Ctrl</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="286"/>
+        <location filename="../interface/InputTab.cpp" line="277"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="286"/>
-        <location filename="../interface/InputTab.cpp" line="1069"/>
+        <location filename="../interface/InputTab.cpp" line="277"/>
+        <location filename="../interface/InputTab.cpp" line="1039"/>
         <source>Keys</source>
         <translation>按键</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="287"/>
-        <location filename="../interface/InputTab.cpp" line="508"/>
-        <location filename="../interface/InputTab.cpp" line="1069"/>
+        <location filename="../interface/InputTab.cpp" line="278"/>
+        <location filename="../interface/InputTab.cpp" line="486"/>
+        <location filename="../interface/InputTab.cpp" line="1039"/>
         <source>Clicks</source>
         <translation>点击</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="297"/>
+        <location filename="../interface/InputTab.cpp" line="288"/>
         <source>Go Premium</source>
         <translation>开始尊享版</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="306"/>
-        <location filename="../interface/InputTab.cpp" line="431"/>
-        <location filename="../interface/InputTab.cpp" line="724"/>
-        <location filename="../interface/InputTab.cpp" line="1099"/>
+        <location filename="../interface/InputTab.cpp" line="297"/>
+        <location filename="../interface/InputTab.cpp" line="417"/>
+        <location filename="../interface/InputTab.cpp" line="702"/>
+        <location filename="../interface/InputTab.cpp" line="1069"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="319"/>
-        <location filename="../interface/InputTab.cpp" line="443"/>
-        <location filename="../interface/InputTab.cpp" line="736"/>
-        <location filename="../interface/InputTab.cpp" line="1111"/>
+        <location filename="../interface/InputTab.cpp" line="305"/>
+        <location filename="../interface/InputTab.cpp" line="425"/>
+        <location filename="../interface/InputTab.cpp" line="710"/>
+        <location filename="../interface/InputTab.cpp" line="1077"/>
         <source>&amp;Export to .csv</source>
         <translation>导出为 CSV 格式(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="323"/>
-        <location filename="../interface/InputTab.cpp" line="446"/>
-        <location filename="../interface/InputTab.cpp" line="740"/>
+        <location filename="../interface/InputTab.cpp" line="309"/>
+        <location filename="../interface/InputTab.cpp" line="428"/>
+        <location filename="../interface/InputTab.cpp" line="714"/>
         <source>&amp;Export to .png</source>
         <translation>导出为 PNG 格式(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="328"/>
-        <location filename="../interface/InputTab.cpp" line="450"/>
-        <location filename="../interface/InputTab.cpp" line="744"/>
-        <location filename="../interface/InputTab.cpp" line="1115"/>
+        <location filename="../interface/InputTab.cpp" line="314"/>
+        <location filename="../interface/InputTab.cpp" line="432"/>
+        <location filename="../interface/InputTab.cpp" line="718"/>
+        <location filename="../interface/InputTab.cpp" line="1081"/>
         <source>&amp;Export Wizard</source>
         <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="348"/>
+        <location filename="../interface/InputTab.cpp" line="334"/>
         <source>Last 12 hours</source>
         <translation>最近 12 小时</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="349"/>
+        <location filename="../interface/InputTab.cpp" line="335"/>
         <source>Last 24 hours</source>
         <translation>最近 24 小时</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="350"/>
+        <location filename="../interface/InputTab.cpp" line="336"/>
         <source>Last 7 days</source>
         <translation>最近 7 天</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="351"/>
+        <location filename="../interface/InputTab.cpp" line="337"/>
         <source>Last 7 weeks</source>
         <translation>最近 7 周</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="352"/>
+        <location filename="../interface/InputTab.cpp" line="338"/>
         <source>Last 7 months</source>
         <translation>最近 7 个月</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="355"/>
+        <location filename="../interface/InputTab.cpp" line="341"/>
         <source>Group by Hours</source>
-        <translation>每小时分组</translation>
+        <translation>按小时分组</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="356"/>
+        <location filename="../interface/InputTab.cpp" line="342"/>
         <source>Group by Days</source>
-        <translation>每日分组</translation>
+        <translation>按日分组</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="357"/>
+        <location filename="../interface/InputTab.cpp" line="343"/>
         <source>Group by Weeks</source>
-        <translation>每周分组</translation>
+        <translation>按周分组</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="359"/>
+        <location filename="../interface/InputTab.cpp" line="345"/>
         <source>Group by Months</source>
-        <translation>每月分组</translation>
+        <translation>按月分组</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="360"/>
+        <location filename="../interface/InputTab.cpp" line="346"/>
         <source>Group by Years</source>
-        <translation>每年分组</translation>
+        <translation>按年分组</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="407"/>
-        <location filename="../interface/InputTab.cpp" line="711"/>
+        <location filename="../interface/InputTab.cpp" line="393"/>
+        <location filename="../interface/InputTab.cpp" line="689"/>
         <source>Enable Heatmap</source>
         <translation>开启热力图</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="417"/>
+        <location filename="../interface/InputTab.cpp" line="403"/>
         <source>Prune older than 3 months</source>
         <translation>丢弃 3 个月以上的历史</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="459"/>
-        <location filename="../interface/InputTab.cpp" line="752"/>
+        <location filename="../interface/InputTab.cpp" line="441"/>
+        <location filename="../interface/InputTab.cpp" line="726"/>
         <source>Share</source>
         <translation>分享</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="502"/>
+        <location filename="../interface/InputTab.cpp" line="480"/>
         <source>&lt;b&gt;Buttons Usage&lt;/b&gt;</source>
         <translation>&lt;b&gt;按键使用&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="508"/>
+        <location filename="../interface/InputTab.cpp" line="486"/>
         <source>Button</source>
         <translation>按键</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="537"/>
+        <location filename="../interface/InputTab.cpp" line="515"/>
         <source>Mouse heat map selected</source>
         <translation>已选择鼠标热力图</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="541"/>
+        <location filename="../interface/InputTab.cpp" line="519"/>
         <source>Switch to button view</source>
         <translation>切换至按键界面</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="548"/>
+        <location filename="../interface/InputTab.cpp" line="526"/>
         <source>Switch to mouse heat map</source>
         <translation>切换至鼠标热力图</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="553"/>
+        <location filename="../interface/InputTab.cpp" line="531"/>
         <source>Button view selected</source>
         <translation>已选择按键界面</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="637"/>
+        <location filename="../interface/InputTab.cpp" line="615"/>
         <source>Key</source>
         <translation>按键</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="637"/>
+        <location filename="../interface/InputTab.cpp" line="615"/>
         <source>Amount</source>
         <translation>数量</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="679"/>
+        <location filename="../interface/InputTab.cpp" line="657"/>
         <source>Layout:</source>
         <translation>布局：</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="770"/>
+        <location filename="../interface/InputTab.cpp" line="740"/>
         <source>Application:</source>
         <translation>应用：</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="777"/>
+        <location filename="../interface/InputTab.cpp" line="747"/>
         <source>Per-App Stats Disabled</source>
         <translation>已禁用分应用统计</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="777"/>
-        <location filename="../interface/InputTab.cpp" line="780"/>
-        <location filename="../interface/InputTab.cpp" line="783"/>
-        <location filename="../interface/InputTab.cpp" line="1850"/>
-        <location filename="../interface/InputTab.cpp" line="1851"/>
-        <location filename="../interface/InputTab.cpp" line="1880"/>
-        <location filename="../interface/InputTab.cpp" line="1881"/>
+        <location filename="../interface/InputTab.cpp" line="747"/>
+        <location filename="../interface/InputTab.cpp" line="750"/>
+        <location filename="../interface/InputTab.cpp" line="753"/>
+        <location filename="../interface/InputTab.cpp" line="1814"/>
+        <location filename="../interface/InputTab.cpp" line="1815"/>
+        <location filename="../interface/InputTab.cpp" line="1844"/>
+        <location filename="../interface/InputTab.cpp" line="1845"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="780"/>
-        <location filename="../interface/InputTab.cpp" line="1850"/>
-        <location filename="../interface/InputTab.cpp" line="1851"/>
-        <location filename="../interface/InputTab.cpp" line="1880"/>
-        <location filename="../interface/InputTab.cpp" line="1881"/>
+        <location filename="../interface/InputTab.cpp" line="750"/>
+        <location filename="../interface/InputTab.cpp" line="1814"/>
+        <location filename="../interface/InputTab.cpp" line="1815"/>
+        <location filename="../interface/InputTab.cpp" line="1844"/>
+        <location filename="../interface/InputTab.cpp" line="1845"/>
         <source>Premium Only</source>
         <translation>尊享版独享</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="841"/>
-        <location filename="../interface/InputTab.cpp" line="1140"/>
+        <location filename="../interface/InputTab.cpp" line="811"/>
+        <location filename="../interface/InputTab.cpp" line="1106"/>
         <source>&lt;b&gt;Today&lt;/b&gt;</source>
         <translation>&lt;b&gt;今天&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="853"/>
-        <location filename="../interface/InputTab.cpp" line="1150"/>
+        <location filename="../interface/InputTab.cpp" line="823"/>
+        <location filename="../interface/InputTab.cpp" line="1116"/>
         <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
         <translation>&lt;b&gt;昨天&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="865"/>
+        <location filename="../interface/InputTab.cpp" line="835"/>
         <source>&lt;b&gt;Unpulsed&lt;/b&gt;</source>
         <translation>&lt;b&gt;未 Pulse&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="877"/>
-        <location filename="../interface/InputTab.cpp" line="1160"/>
+        <location filename="../interface/InputTab.cpp" line="847"/>
+        <location filename="../interface/InputTab.cpp" line="1126"/>
         <source>&lt;b&gt;All time&lt;/b&gt;</source>
         <translation>&lt;b&gt;全部&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="936"/>
+        <location filename="../interface/InputTab.cpp" line="906"/>
         <source>Keyboard heat map selected</source>
         <translation>已选择键盘热力图</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="940"/>
-        <location filename="../interface/InputTab.cpp" line="1009"/>
+        <location filename="../interface/InputTab.cpp" line="910"/>
+        <location filename="../interface/InputTab.cpp" line="979"/>
         <source>Switch to table view</source>
         <translation>切换至表格界面</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="948"/>
+        <location filename="../interface/InputTab.cpp" line="918"/>
         <source>Switch to keyboard heat map</source>
         <translation>切换至键盘热力图</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="953"/>
-        <location filename="../interface/InputTab.cpp" line="1021"/>
+        <location filename="../interface/InputTab.cpp" line="923"/>
+        <location filename="../interface/InputTab.cpp" line="991"/>
         <source>Table view selected</source>
         <translation>已选择表格界面</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="1005"/>
+        <location filename="../interface/InputTab.cpp" line="975"/>
         <source>Chart view selected</source>
         <translation>已选择图表界面</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="1016"/>
+        <location filename="../interface/InputTab.cpp" line="986"/>
         <source>Switch to chart view</source>
         <translation>切换至图表界面</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="1069"/>
+        <location filename="../interface/InputTab.cpp" line="1039"/>
         <source>Application</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="1132"/>
-        <location filename="../interface/InputTab.cpp" line="1986"/>
+        <location filename="../interface/InputTab.cpp" line="1098"/>
+        <location filename="../interface/InputTab.cpp" line="1950"/>
         <source>Summary</source>
         <translation>总结</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="1135"/>
-        <location filename="../interface/InputTab.cpp" line="1136"/>
-        <location filename="../interface/InputTab.cpp" line="1145"/>
-        <location filename="../interface/InputTab.cpp" line="1146"/>
-        <location filename="../interface/InputTab.cpp" line="1155"/>
-        <location filename="../interface/InputTab.cpp" line="1156"/>
-        <location filename="../interface/InputTab.cpp" line="2864"/>
-        <location filename="../interface/InputTab.cpp" line="2865"/>
+        <location filename="../interface/InputTab.cpp" line="1101"/>
+        <location filename="../interface/InputTab.cpp" line="1102"/>
+        <location filename="../interface/InputTab.cpp" line="1111"/>
+        <location filename="../interface/InputTab.cpp" line="1112"/>
+        <location filename="../interface/InputTab.cpp" line="1121"/>
+        <location filename="../interface/InputTab.cpp" line="1122"/>
+        <location filename="../interface/InputTab.cpp" line="2828"/>
+        <location filename="../interface/InputTab.cpp" line="2829"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="1904"/>
+        <location filename="../interface/InputTab.cpp" line="1868"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="1965"/>
+        <location filename="../interface/InputTab.cpp" line="1929"/>
         <source>&lt;b&gt;You have disabled per application input statistics in the Settings.&lt;/b&gt;</source>
         <translation>&lt;b&gt;你在设置中禁用了分应用输入统计。&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="1993"/>
+        <location filename="../interface/InputTab.cpp" line="1957"/>
         <source>Summary of </source>
         <translation>总结 </translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2093"/>
+        <location filename="../interface/InputTab.cpp" line="2057"/>
         <source>Left</source>
         <translation>左键</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2093"/>
+        <location filename="../interface/InputTab.cpp" line="2057"/>
         <source>Middle</source>
         <translation>中键</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2093"/>
+        <location filename="../interface/InputTab.cpp" line="2057"/>
         <source>Right</source>
         <translation>右键</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2093"/>
+        <location filename="../interface/InputTab.cpp" line="2057"/>
         <source>Other</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2469"/>
+        <location filename="../interface/InputTab.cpp" line="2433"/>
         <source>keyboard historical data</source>
         <translation>键盘历史数据</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2474"/>
+        <location filename="../interface/InputTab.cpp" line="2438"/>
         <source>mouse historical data</source>
         <translation>鼠标历史数据</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2475"/>
+        <location filename="../interface/InputTab.cpp" line="2439"/>
         <source>Reset Mouse History</source>
         <translation>重置鼠标历史</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2479"/>
+        <location filename="../interface/InputTab.cpp" line="2443"/>
         <source>application historical data</source>
         <translation>应用历史数据</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2480"/>
+        <location filename="../interface/InputTab.cpp" line="2444"/>
         <source>Reset Application History</source>
         <translation>重置应用历史</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2484"/>
+        <location filename="../interface/InputTab.cpp" line="2448"/>
         <source>keyboard and mouse historical data</source>
         <translation>键盘与鼠标历史数据</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2485"/>
+        <location filename="../interface/InputTab.cpp" line="2449"/>
         <source>Reset Keyboard and Mouse History</source>
         <translation>重置键盘与鼠标历史数据</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2489"/>
+        <location filename="../interface/InputTab.cpp" line="2453"/>
         <source>key combination historical data</source>
         <translation>按键组合历史数据</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2490"/>
+        <location filename="../interface/InputTab.cpp" line="2454"/>
         <source>Reset Key Combinations History</source>
         <translation>重置按键组合历史数据</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2494"/>
+        <location filename="../interface/InputTab.cpp" line="2458"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2496"/>
+        <location filename="../interface/InputTab.cpp" line="2460"/>
         <source>Do you want to reset all input data or just the </source>
         <translation>你是准备重置全部输入数据还是说只是</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2499"/>
+        <location filename="../interface/InputTab.cpp" line="2463"/>
         <source>Reset All Data</source>
         <translation>重置全部数据</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2514"/>
-        <location filename="../interface/InputTab.cpp" line="2534"/>
-        <location filename="../interface/InputTab.cpp" line="2555"/>
-        <location filename="../interface/InputTab.cpp" line="2568"/>
-        <location filename="../interface/InputTab.cpp" line="2592"/>
-        <location filename="../interface/InputTab.cpp" line="2608"/>
+        <location filename="../interface/InputTab.cpp" line="2478"/>
+        <location filename="../interface/InputTab.cpp" line="2498"/>
+        <location filename="../interface/InputTab.cpp" line="2519"/>
+        <location filename="../interface/InputTab.cpp" line="2532"/>
+        <location filename="../interface/InputTab.cpp" line="2556"/>
+        <location filename="../interface/InputTab.cpp" line="2572"/>
         <source>Delete stats?</source>
         <translation>删除统计？</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2515"/>
+        <location filename="../interface/InputTab.cpp" line="2479"/>
         <source>Are you sure you want to delete all recorded keyboard statistics? This cannot be undone.</source>
         <translation>确定删除全部键盘统计记录？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2535"/>
+        <location filename="../interface/InputTab.cpp" line="2499"/>
         <source>Are you sure you want to delete all recorded mouse statistics? This cannot be undone.</source>
         <translation>确定删除全部鼠标统计记录？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2556"/>
+        <location filename="../interface/InputTab.cpp" line="2520"/>
         <source>Are you sure you want to delete all recorded per application input statistics? This cannot be undone.</source>
         <translation>确定删除全部分应用统计记录？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2569"/>
+        <location filename="../interface/InputTab.cpp" line="2533"/>
         <source>Are you sure you want to delete all recorded keyboard and mouse statistics? This cannot be undone.</source>
         <translation>确定删除全部键盘与鼠标统计记录？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2593"/>
+        <location filename="../interface/InputTab.cpp" line="2557"/>
         <source>Are you sure you want to delete all recorded key combination statistics? This cannot be undone.</source>
         <translation>确定删除全部按键组合统计记录？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2609"/>
+        <location filename="../interface/InputTab.cpp" line="2573"/>
         <source>Are you sure you want to delete all recorded input statistics? This cannot be undone.</source>
         <translation>确定删除全部输入统计记录？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2638"/>
+        <location filename="../interface/InputTab.cpp" line="2602"/>
         <source>No input devices found, are your &lt;a href=&quot;http://whatpulse.org/kb/content/7/15/en/linux-installation.html&quot;&gt;permissions&lt;/a&gt; set up correctly?</source>
         <translation>未找到输入设备，你的&lt;a href=&quot;http://whatpulse.org/kb/content/7/15/en/linux-installation.html&quot;&gt;权限&lt;/a&gt;设置对了吗？</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2719"/>
+        <location filename="../interface/InputTab.cpp" line="2683"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2725"/>
+        <location filename="../interface/InputTab.cpp" line="2689"/>
         <source>Open File Location</source>
         <translation>打开文件路径</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2731"/>
+        <location filename="../interface/InputTab.cpp" line="2695"/>
         <source>Open Online Profile</source>
         <translation>打开线上个人页</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2746"/>
+        <location filename="../interface/InputTab.cpp" line="2710"/>
         <source>Ignore application?</source>
         <translation>忽略应用？</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2747"/>
+        <location filename="../interface/InputTab.cpp" line="2711"/>
         <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
         <translation>确定忽略应用”%1“？这将同时移除该应用的历史。</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2800"/>
+        <location filename="../interface/InputTab.cpp" line="2764"/>
         <source>Not yet</source>
         <translation>先不要</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2801"/>
+        <location filename="../interface/InputTab.cpp" line="2765"/>
         <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
         <translation>该应用尚未上传到网站，请一小时左右之后再试。</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2824"/>
+        <location filename="../interface/InputTab.cpp" line="2788"/>
         <source>Prune Mouse Heatmap</source>
         <translation>丢弃鼠标热力图</translation>
     </message>
     <message>
-        <location filename="../interface/InputTab.cpp" line="2825"/>
+        <location filename="../interface/InputTab.cpp" line="2789"/>
         <source>By not pruning your mouse heatmap, your database will get pretty large and possibly slow WhatPulse down. Stop pruning?</source>
         <translation>如果不丢弃鼠标热力图的话，数据库将会变得相当大并拖慢 WhatPulse。停止丢弃？</translation>
     </message>
@@ -1735,22 +1727,22 @@ Please check your permissions on: %2</source>
 <context>
     <name>NetworkInterfaces_WiredvsWirelessButtons</name>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="561"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="557"/>
         <source>Show Wired</source>
         <translation>显示有线</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="563"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="559"/>
         <source>Hide Wired</source>
         <translation>隐藏有线</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="572"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="568"/>
         <source>Show Wifi</source>
         <translation>显示无线</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="574"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="570"/>
         <source>Hide Wifi</source>
         <translation>隐藏无线</translation>
     </message>
@@ -2111,130 +2103,130 @@ Please check your permissions on: %2</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="64"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="60"/>
         <source>&amp;Export Wizard</source>
         <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="74"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="70"/>
         <source>Go Premium</source>
         <translation>开始尊享版</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="106"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="102"/>
         <source>Testing..</source>
         <translation>测试中…</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="110"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="106"/>
         <source>Internet:</source>
         <translation>网络：</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="116"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="112"/>
         <source>Show in bytes</source>
         <translation>以字节计</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="117"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="113"/>
         <source>Show in bits</source>
         <translation>以比特计</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="136"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="191"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="132"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="187"/>
         <source>Summary</source>
         <translation>总结</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="139"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="140"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="149"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="150"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="159"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="160"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="539"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="540"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="135"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="136"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="145"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="146"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="155"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="156"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="535"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="536"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="144"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="140"/>
         <source>&lt;b&gt;Today&lt;/b&gt;</source>
         <translation>&lt;b&gt;今天&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="145"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="155"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="165"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="141"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="151"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="161"/>
         <source>Downloaded:</source>
         <translation>下载：</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="146"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="156"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="166"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="142"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="152"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="162"/>
         <source>Uploaded:</source>
         <translation>上传：</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="154"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="150"/>
         <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
         <translation>&lt;b&gt;昨天&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="164"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="160"/>
         <source>&lt;b&gt;All time&lt;/b&gt;</source>
         <translation>&lt;b&gt;全部&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="255"/>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="341"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="251"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="337"/>
         <source>Summary of </source>
         <translation>总结 </translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="388"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="384"/>
         <source>(Per-application bandwidth is disabled)</source>
         <translation>（已禁用分应用带宽）</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="394"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="390"/>
         <source>Total</source>
         <translation>总</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="405"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="401"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="411"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="407"/>
         <source>Open File Location</source>
         <translation>打开文件路径</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="417"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="413"/>
         <source>Open Online Profile</source>
         <translation>打开线上个人页</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="432"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="428"/>
         <source>Ignore application?</source>
         <translation>忽略应用？</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="433"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="429"/>
         <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
         <translation>确定忽略应用”%1“？这将同时移除该应用的历史。</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="485"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="481"/>
         <source>Not yet</source>
         <translation>先不要</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="486"/>
+        <location filename="../interface/NetworkTab/NetworkApplications.cpp" line="482"/>
         <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
         <translation>该应用尚未上传到网站，请一小时左右之后再试。</translation>
     </message>
@@ -2267,37 +2259,37 @@ Please check your permissions on: %2</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="94"/>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="90"/>
         <source>&amp;Export to .csv</source>
         <translation>导出为 CSV 格式(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="97"/>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="93"/>
         <source>&amp;Export to .png</source>
         <translation>导出为 PNG 格式(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="101"/>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="97"/>
         <source>&amp;Export Wizard</source>
         <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="208"/>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="204"/>
         <source>Network heat map selected</source>
         <translation>已选择网络热力图</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="212"/>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="208"/>
         <source>Switch to table view</source>
         <translation>切换至表格界面</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="220"/>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="216"/>
         <source>Switch to network heat map</source>
         <translation>切换至网络热力图</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="225"/>
+        <location filename="../interface/NetworkTab/NetworkCountry.cpp" line="221"/>
         <source>Table view selected</source>
         <translation>已选择表格界面</translation>
     </message>
@@ -2398,27 +2390,27 @@ Please check your permissions on: %2</source>
     <name>NetworkTabInterfaces</name>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="26"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="479"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="487"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="475"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="483"/>
         <source>Interface</source>
         <translation>网卡</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="26"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="479"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="475"/>
         <source>Current download</source>
         <translation>当前下载</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="27"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="480"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="476"/>
         <source>Current upload</source>
         <translation>当前上传</translation>
     </message>
     <message>
         <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="27"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="480"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="488"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="476"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="484"/>
         <source>IP-address</source>
         <translation>IP 地址</translation>
     </message>
@@ -2438,99 +2430,99 @@ Please check your permissions on: %2</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="81"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="77"/>
         <source>&amp;Export Wizard</source>
         <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="106"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="102"/>
         <source>Testing..</source>
         <translation>测试中…</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="111"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="107"/>
         <source>Internet:</source>
         <translation>网络：</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="123"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="119"/>
         <source>Show in bytes</source>
         <translation>以字节计</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="124"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="120"/>
         <source>Show in bits</source>
         <translation>以比特计</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="142"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="205"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="138"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="201"/>
         <source>Summary</source>
         <translation>总结</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="145"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="146"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="155"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="156"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="165"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="166"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="373"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="374"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="141"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="142"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="151"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="152"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="161"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="162"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="369"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="370"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="150"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="146"/>
         <source>&lt;b&gt;Today&lt;/b&gt;</source>
         <translation>&lt;b&gt;今天&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="151"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="161"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="171"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="147"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="157"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="167"/>
         <source>Downloaded:</source>
         <translation>下载：</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="152"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="162"/>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="172"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="148"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="158"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="168"/>
         <source>Uploaded:</source>
         <translation>上传：</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="160"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="156"/>
         <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
         <translation>&lt;b&gt;昨天&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="170"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="166"/>
         <source>&lt;b&gt;All time&lt;/b&gt;</source>
         <translation>&lt;b&gt;全部&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="201"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="197"/>
         <source>Summary of Wireless Bandwidth</source>
         <translation>无线带宽总结</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="203"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="199"/>
         <source>Summary of Wired Bandwidth</source>
         <translation>有线带宽总结</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="440"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="436"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="487"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="483"/>
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="488"/>
+        <location filename="../interface/NetworkTab/NetworkInterfaces.cpp" line="484"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
@@ -2568,83 +2560,83 @@ Please check your permissions on: %2</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="68"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="64"/>
         <source>&amp;Export Wizard</source>
         <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="77"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="73"/>
         <source>Go Premium</source>
         <translation>开始尊享版</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="102"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="98"/>
         <source>Record Unknown Traffic Types</source>
         <translation>记录未知流量类型</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="103"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="99"/>
         <source>By recording unknown traffic types, your database will get pretty large and possibly slow WhatPulse down. Still record unknown?</source>
         <translation>如果记录未知流量类型的话，数据库将会变得相当大并拖慢 WhatPulse。依然记录？</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="116"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="112"/>
         <source>Summary</source>
         <translation>总结</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="119"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="120"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="129"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="130"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="139"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="140"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="329"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="330"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="115"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="116"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="125"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="126"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="135"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="136"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="325"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="326"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="124"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="120"/>
         <source>&lt;b&gt;Today&lt;/b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="125"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="135"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="145"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="121"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="131"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="141"/>
         <source>Downloaded:</source>
         <translation>下载：</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="126"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="136"/>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="146"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="122"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="132"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="142"/>
         <source>Uploaded:</source>
         <translation>上传：</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="134"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="130"/>
         <source>&lt;b&gt;Yesterday&lt;/b&gt;</source>
         <translation>&lt;b&gt;昨天&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="144"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="140"/>
         <source>&lt;b&gt;All time&lt;/b&gt;</source>
         <translation>&lt;b&gt;全部&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="169"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="165"/>
         <source>All Traffic</source>
         <translation>全部流量</translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="225"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="221"/>
         <source>Summary of </source>
         <translation>总结 </translation>
     </message>
     <message>
-        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="268"/>
+        <location filename="../interface/NetworkTab/NetworkTypeTraffic.cpp" line="264"/>
         <source>(Per-type bandwidth is disabled)</source>
         <translation>（已禁用分类型带宽）</translation>
     </message>
@@ -3085,25 +3077,25 @@ Unpulsed: %2 down, %3 up</source>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="331"/>
-        <location filename="../interface/SettingsTab.cpp" line="820"/>
+        <location filename="../interface/SettingsTab.cpp" line="809"/>
         <source>Auto</source>
         <translation>自动</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="331"/>
-        <location filename="../interface/SettingsTab.cpp" line="822"/>
+        <location filename="../interface/SettingsTab.cpp" line="811"/>
         <source>Black</source>
         <translation>黑</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="331"/>
-        <location filename="../interface/SettingsTab.cpp" line="824"/>
+        <location filename="../interface/SettingsTab.cpp" line="813"/>
         <source>White</source>
         <translation>白</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="333"/>
-        <location filename="../interface/SettingsTab.cpp" line="827"/>
+        <location filename="../interface/SettingsTab.cpp" line="816"/>
         <source>Development</source>
         <translation>开发</translation>
     </message>
@@ -3180,92 +3172,92 @@ Unpulsed: %2 down, %3 up</source>
         <translation>重启</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="467"/>
+        <location filename="../interface/SettingsTab.cpp" line="461"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="473"/>
+        <location filename="../interface/SettingsTab.cpp" line="465"/>
         <source>&amp;Open Data Directory</source>
         <translation>打开数据目录(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="480"/>
+        <location filename="../interface/SettingsTab.cpp" line="472"/>
         <source>&amp;Start Online Backup</source>
         <translation>开始线上备份(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="487"/>
+        <location filename="../interface/SettingsTab.cpp" line="479"/>
         <source>Re-upload &amp;applications</source>
         <translation>重新上传应用(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="493"/>
+        <location filename="../interface/SettingsTab.cpp" line="485"/>
         <source>Empty local &amp;database</source>
         <translation>清空本地数据库(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="499"/>
+        <location filename="../interface/SettingsTab.cpp" line="491"/>
         <source>Update &amp;GeoIP database</source>
         <translation>更新地理 IP 数据库(&amp;G)</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="506"/>
+        <location filename="../interface/SettingsTab.cpp" line="498"/>
         <source>Update Network Port Description database</source>
         <translation>更新网络端口描述数据库</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="513"/>
+        <location filename="../interface/SettingsTab.cpp" line="505"/>
         <source>&amp;Upload database</source>
         <translation>上传数据库(&amp;U)</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="525"/>
+        <location filename="../interface/SettingsTab.cpp" line="517"/>
         <source>Check macOS Permissions</source>
         <translation>检查 macOS 权限</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="549"/>
+        <location filename="../interface/SettingsTab.cpp" line="538"/>
         <source>Uploading applications</source>
         <translation>上传应用</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="576"/>
+        <location filename="../interface/SettingsTab.cpp" line="565"/>
         <source>Uploading Apps</source>
         <translation>上传应用</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="577"/>
+        <location filename="../interface/SettingsTab.cpp" line="566"/>
         <source>Applications have been marked for upload. It might take an hour before they appear on the website.</source>
-        <translation>应用已标记为上传。到它显示到网站上可能需要一个小时。</translation>
+        <translation>应用已标记为上传。它显示到网站上可能需要一个小时。</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="594"/>
+        <location filename="../interface/SettingsTab.cpp" line="583"/>
         <source>Empty Database</source>
         <translation>清空数据库</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="595"/>
+        <location filename="../interface/SettingsTab.cpp" line="584"/>
         <source>Emptying out your local database will destroy all local statistics and logout your account. There is no recovery for this, continue?</source>
         <translation>清空本地数据库将摧毁全部本地统计数据并退出登录。这是无法恢复的，继续？</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="614"/>
+        <location filename="../interface/SettingsTab.cpp" line="603"/>
         <source>Start Online Backup?</source>
         <translation>开始线上备份？</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="615"/>
+        <location filename="../interface/SettingsTab.cpp" line="604"/>
         <source>Starting a backup will restart the client and show the backup window. Continue?</source>
         <translation>开始备份将重启客户端并显示备份窗口。继续？</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="773"/>
+        <location filename="../interface/SettingsTab.cpp" line="762"/>
         <source>Settings saved...</source>
         <translation>设置已保存……</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab.cpp" line="812"/>
+        <location filename="../interface/SettingsTab.cpp" line="801"/>
         <source>Weekly online backups (premium only)</source>
         <translation>每周线上备份（尊享版特权）</translation>
     </message>
@@ -3464,267 +3456,273 @@ Unpulsed: %2 down, %3 up</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="91"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="343"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="512"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="525"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="86"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="327"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="498"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="511"/>
         <source>Select label to edit..</source>
         <translation>选择标签以编辑……</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="108"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="103"/>
         <source>Delete label</source>
         <translation>删除标签</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="123"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="118"/>
         <source>Insert statistic:</source>
         <translation>插入统计：</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="124"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="429"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="119"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="413"/>
         <source>Unpulsed Keys</source>
         <translation>未 Pulse 按键</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="125"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="431"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="120"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="415"/>
         <source>Unpulsed Clicks</source>
         <translation>未 Pulse 点击</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="126"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="433"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="121"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="417"/>
         <source>Unpulsed Download</source>
         <translation>未 Pulse 下载</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="127"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="435"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="122"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="419"/>
         <source>Unpulsed Upload</source>
         <translation>未 Pulse 上传</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="128"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="437"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="123"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="421"/>
         <source>Unpulsed Uptime</source>
         <translation>未 Pulse 上线时长</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="129"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="439"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="124"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="423"/>
         <source>Unpulsed Click Rate</source>
         <translation>未 Pulse 点击速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="130"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="441"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="125"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="425"/>
         <source>Unpulsed Key Rate</source>
         <translation>未 Pulse 按键速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="131"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="443"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="126"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="427"/>
         <source>Unpulsed Download Rate</source>
         <translation>未 Pulse 下载速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="132"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="445"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="127"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="429"/>
         <source>Unpulsed Upload Rate</source>
         <translation>未 Pulse 上传速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="133"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="447"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="128"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="431"/>
         <source>Current Click Rate</source>
         <translation>当前点击速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="134"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="449"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="129"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="433"/>
         <source>Current Key Rate</source>
         <translation>当前按键速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="135"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="451"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="130"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="435"/>
         <source>Current Download Rate</source>
         <translation>当前下载速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="136"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="453"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="131"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="437"/>
         <source>Current Upload Rate</source>
         <translation>当前上传速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="137"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="455"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="132"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="439"/>
+        <source>Current Uptime</source>
+        <translation>当前上线时长</translation>
+    </message>
+    <message>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="133"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="441"/>
         <source>Total Keys</source>
         <translation>总按键</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="138"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="457"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="134"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="443"/>
         <source>Total Clicks</source>
         <translation>总点击</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="139"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="459"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="135"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="445"/>
         <source>Total Download</source>
         <translation>总下载</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="140"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="461"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="136"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="447"/>
         <source>Total Upload</source>
         <translation>总上传</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="141"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="463"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="137"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="449"/>
         <source>Total Uptime</source>
         <translation>总上线时长</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="142"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="465"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="138"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="451"/>
         <source>Total Click Rate</source>
         <translation>总点击速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="143"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="467"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="139"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="453"/>
         <source>Total Key Rate</source>
         <translation>总按键速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="144"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="469"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="140"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="455"/>
         <source>Total Download Rate</source>
         <translation>总下载速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="145"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="471"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="141"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="457"/>
         <source>Total Upload Rate</source>
         <translation>总上传速度</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="146"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="473"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="142"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="459"/>
         <source>Rank Keys</source>
         <translation>按键排名</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="147"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="475"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="143"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="461"/>
         <source>Rank Clicks</source>
         <translation>点击排名</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="148"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="477"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="144"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="463"/>
         <source>Rank Download</source>
         <translation>下载排名</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="149"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="479"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="145"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="465"/>
         <source>Rank Upload</source>
         <translation>上传排名</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="150"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="481"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="146"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="467"/>
         <source>Rank Uptime</source>
         <translation>上线时长排名</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="151"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="483"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="147"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="469"/>
         <source>Today Keys</source>
         <translation>今日按键</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="152"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="485"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="148"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="471"/>
         <source>Today Clicks</source>
         <translation>今日点击</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="153"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="487"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="149"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="473"/>
         <source>Today Download</source>
         <translation>今日下载</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="154"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="489"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="150"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="475"/>
         <source>Today Upload</source>
         <translation>今日上传</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="173"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="169"/>
         <source>Snap to grid</source>
         <translation>对齐到网格</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="179"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="176"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="200"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="188"/>
         <source>Call to Center</source>
         <translation>移动到中央</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="256"/>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="264"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="240"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="248"/>
         <source>Reset to default</source>
         <translation>重置为初始状态</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="268"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="252"/>
         <source>Background color: </source>
         <translation>背景颜色： </translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="272"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="256"/>
         <source>Font color: </source>
         <translation>文字颜色： </translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="282"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="266"/>
         <source>Font size: </source>
         <translation>文字大小： </translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="301"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="285"/>
         <source>Transparency: </source>
         <translation>透明度： </translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="320"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="304"/>
         <source>Close Geek Window on double click</source>
         <translation>双击关闭悬浮窗</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="326"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="310"/>
         <source>Put Geek Window on top</source>
         <translation>悬浮窗置顶</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="594"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="580"/>
         <source>Reset to default?</source>
         <translation>重置为初始状态？</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="595"/>
+        <location filename="../interface/SettingsTab/SettingsGeekWindow.cpp" line="581"/>
         <source>Do you want to reset the Geek Window to default?
 This will reset any custom layouts!</source>
         <translation>是否将悬浮窗重置为初始状态？
@@ -3919,7 +3917,7 @@ This will reset any custom layouts!</source>
     </message>
     <message>
         <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="18"/>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="409"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="399"/>
         <source> Test proxy</source>
         <translation> 测试代理</translation>
     </message>
@@ -3929,82 +3927,82 @@ This will reset any custom layouts!</source>
         <translation>代理需要认证</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="98"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="88"/>
         <source>Enable Client API</source>
         <translation>开启客户端 API</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="148"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="138"/>
         <source>Hostname:</source>
         <translation>服务器：</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="151"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="141"/>
         <source>Port:</source>
         <translation>端口：</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="167"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="157"/>
         <source>Username:</source>
         <translation>用户名：</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="170"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="160"/>
         <source>Password:</source>
         <translation>密码：</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="202"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="192"/>
         <source>Client API</source>
         <translation>客户端 API</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="209"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="199"/>
         <source>The Client API is a way to extract real-time information from the WhatPulse client. You can use this to feed your data into another application. Find out more in our &lt;a href=&quot;http://dev.whatpulse.org&quot;&gt;Developer Center&lt;/a&gt;</source>
         <translation>客户端 API 是一种从 WhatPulse 客户端提取实时信息的方式。你可以用它去填充别的应用中的数据。从我们的&lt;a href=&quot;http://dev.whatpulse.org&quot;&gt;开发者中心&lt;/a&gt;寻找更多信息</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="230"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="220"/>
         <source>Listen on port:</source>
         <translation>监听端口：</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="236"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="226"/>
         <source>Enter a value between 1024 and 65535</source>
         <translation>输入一个 1024 到 65535 之间的数字</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="253"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="243"/>
         <source>IPs that are allowed to connect (one per line):</source>
         <translation>允许连接的 IP（一行一个）：</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="371"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="361"/>
         <source>Not enough info</source>
         <translation>信息不足</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="372"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="362"/>
         <source>Please fill out both the proxy hostname and port number before testing.</source>
         <translation>测试前请填写代理主机和端口号。</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="378"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="368"/>
         <source> Testing..</source>
         <translation>测试中…</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="415"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="405"/>
         <source>Success!</source>
         <translation>成功！</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="415"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="405"/>
         <source>Proxy test worked!</source>
         <translation>代理测试可用！</translation>
     </message>
     <message>
-        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="417"/>
+        <location filename="../interface/SettingsTab/SettingsProxy.cpp" line="407"/>
         <source>Proxy test error!</source>
         <translation>代理测试错误！</translation>
     </message>
@@ -4072,44 +4070,50 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="43"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="75"/>
-        <location filename="../interface/widgets/timeperiod.cpp" line="210"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="135"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="243"/>
         <source>real-time</source>
         <translation>实时</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="48"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="77"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="136"/>
         <source>today</source>
         <translation>今天</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="52"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="79"/>
-        <location filename="../interface/widgets/timeperiod.cpp" line="133"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="134"/>
         <source>yesterday</source>
         <translation>昨天</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="56"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="81"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="137"/>
         <source>week</source>
         <translation>本周</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="60"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="83"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="138"/>
         <source>month</source>
         <translation>本月</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="63"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="85"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="139"/>
         <source>6 months</source>
         <translation>最近 6 个月</translation>
     </message>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="64"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="87"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="140"/>
         <source>year</source>
         <translation>今年</translation>
     </message>
@@ -4121,7 +4125,8 @@ This will reset any custom layouts!</source>
     <message>
         <location filename="../interface/widgets/timeperiod.cpp" line="71"/>
         <location filename="../interface/widgets/timeperiod.cpp" line="89"/>
-        <location filename="../interface/widgets/timeperiod.cpp" line="217"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="141"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="250"/>
         <source>custom</source>
         <translation>自定义</translation>
     </message>
@@ -4129,22 +4134,22 @@ This will reset any custom layouts!</source>
 <context>
     <name>TimePeriodCustomTimeWindow_IntroPage</name>
     <message>
-        <location filename="../interface/widgets/timeperiod.cpp" line="363"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="396"/>
         <source>Select the start and end date of the period you&apos;d like to see statistics from.</source>
         <translation>选择你想看的统计周期的时间范围。</translation>
     </message>
     <message>
-        <location filename="../interface/widgets/timeperiod.cpp" line="365"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="398"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../interface/widgets/timeperiod.cpp" line="369"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="402"/>
         <source>From:</source>
         <translation>从：</translation>
     </message>
     <message>
-        <location filename="../interface/widgets/timeperiod.cpp" line="381"/>
+        <location filename="../interface/widgets/timeperiod.cpp" line="414"/>
         <source>To:</source>
         <translation>到：</translation>
     </message>
@@ -4416,251 +4421,251 @@ This will reset any custom layouts!</source>
         <translation>上线时长</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="140"/>
-        <location filename="../interface/UptimeTab.cpp" line="271"/>
+        <location filename="../interface/UptimeTab.cpp" line="141"/>
+        <location filename="../interface/UptimeTab.cpp" line="269"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="152"/>
-        <location filename="../interface/UptimeTab.cpp" line="283"/>
+        <location filename="../interface/UptimeTab.cpp" line="149"/>
+        <location filename="../interface/UptimeTab.cpp" line="277"/>
         <source>&amp;Export to .csv</source>
         <translation>导出为 CSV 格式(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="156"/>
-        <location filename="../interface/UptimeTab.cpp" line="286"/>
+        <location filename="../interface/UptimeTab.cpp" line="153"/>
+        <location filename="../interface/UptimeTab.cpp" line="280"/>
         <source>&amp;Export Wizard</source>
         <translation>导出向导(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="186"/>
+        <location filename="../interface/UptimeTab.cpp" line="183"/>
         <source>Go Premium</source>
         <translation>开始尊享版</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="205"/>
+        <location filename="../interface/UptimeTab.cpp" line="202"/>
         <source>&lt;h3&gt;Favorite reboot days&lt;/h3&gt;</source>
         <translation>&lt;h3&gt;重启日之最&lt;/h3&gt;</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="231"/>
+        <location filename="../interface/UptimeTab.cpp" line="228"/>
         <source>Sun</source>
         <translation>日</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="231"/>
+        <location filename="../interface/UptimeTab.cpp" line="228"/>
         <source>Mon</source>
         <translation>一</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="231"/>
+        <location filename="../interface/UptimeTab.cpp" line="228"/>
         <source>Tue</source>
         <translation>二</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="231"/>
+        <location filename="../interface/UptimeTab.cpp" line="228"/>
         <source>Wed</source>
         <translation>三</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="232"/>
+        <location filename="../interface/UptimeTab.cpp" line="229"/>
         <source>Thu</source>
         <translation>四</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="232"/>
+        <location filename="../interface/UptimeTab.cpp" line="229"/>
         <source>Fri</source>
         <translation>五</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="232"/>
+        <location filename="../interface/UptimeTab.cpp" line="229"/>
         <source>Sat</source>
         <translation>六</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="247"/>
+        <location filename="../interface/UptimeTab.cpp" line="244"/>
         <source>Show only recently used applications</source>
         <translation>仅显示最近使用的应用</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="254"/>
+        <location filename="../interface/UptimeTab.cpp" line="251"/>
         <source>Show only running applications</source>
         <translation>仅显示运行着的应用</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="305"/>
-        <location filename="../interface/UptimeTab.cpp" line="306"/>
-        <location filename="../interface/UptimeTab.cpp" line="307"/>
-        <location filename="../interface/UptimeTab.cpp" line="308"/>
-        <location filename="../interface/UptimeTab.cpp" line="309"/>
-        <location filename="../interface/UptimeTab.cpp" line="310"/>
+        <location filename="../interface/UptimeTab.cpp" line="299"/>
+        <location filename="../interface/UptimeTab.cpp" line="300"/>
+        <location filename="../interface/UptimeTab.cpp" line="301"/>
+        <location filename="../interface/UptimeTab.cpp" line="302"/>
+        <location filename="../interface/UptimeTab.cpp" line="303"/>
+        <location filename="../interface/UptimeTab.cpp" line="304"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="321"/>
+        <location filename="../interface/UptimeTab.cpp" line="315"/>
         <source>Unpulsed uptime:</source>
         <translation>未 Pulse 上线时长：</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="324"/>
+        <location filename="../interface/UptimeTab.cpp" line="318"/>
         <source>Current uptime:</source>
         <translation>当前上线时长：</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="327"/>
+        <location filename="../interface/UptimeTab.cpp" line="321"/>
         <source>Total uptime:</source>
         <translation>总上线时长：</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="330"/>
+        <location filename="../interface/UptimeTab.cpp" line="324"/>
         <source>Longest uptime:</source>
         <translation>最长上线时长：</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="333"/>
+        <location filename="../interface/UptimeTab.cpp" line="327"/>
         <source>Average uptime:</source>
         <translation>平均上线时长：</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="336"/>
+        <location filename="../interface/UptimeTab.cpp" line="330"/>
         <source>Total reboots:</source>
         <translation>总重启次数：</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="346"/>
+        <location filename="../interface/UptimeTab.cpp" line="340"/>
         <source>Reboot history for </source>
         <translation>重启于 </translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="391"/>
+        <location filename="../interface/UptimeTab.cpp" line="385"/>
         <source>No reboots found</source>
         <translation>当天没有重启</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="404"/>
+        <location filename="../interface/UptimeTab.cpp" line="398"/>
         <source>Reboot history</source>
         <translation>重启历史</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="463"/>
+        <location filename="../interface/UptimeTab.cpp" line="457"/>
         <source>Application</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="463"/>
+        <location filename="../interface/UptimeTab.cpp" line="457"/>
         <source>Total time</source>
         <translation>总时间</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="464"/>
+        <location filename="../interface/UptimeTab.cpp" line="458"/>
         <source>Total active time</source>
         <translation>总活跃时间</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="491"/>
+        <location filename="../interface/UptimeTab.cpp" line="485"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="497"/>
+        <location filename="../interface/UptimeTab.cpp" line="491"/>
         <source>Open File Location</source>
         <translation>打开文件路径</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="503"/>
+        <location filename="../interface/UptimeTab.cpp" line="497"/>
         <source>Open Online Profile</source>
         <translation>打开线上个人页</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="518"/>
+        <location filename="../interface/UptimeTab.cpp" line="512"/>
         <source>Ignore application?</source>
         <translation>忽略应用？</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="519"/>
+        <location filename="../interface/UptimeTab.cpp" line="513"/>
         <source>Are you sure you want to ignore application &apos;%1&apos; ? This will also remove this applications history.</source>
         <translation>确定忽略应用”%1“？这将同时移除该应用的历史。</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="570"/>
+        <location filename="../interface/UptimeTab.cpp" line="564"/>
         <source>Not yet</source>
         <translation>先不要</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="571"/>
+        <location filename="../interface/UptimeTab.cpp" line="565"/>
         <source>This application has not been uploaded to the website yet, please check back in an hour or so.</source>
         <translation>该应用尚未上传到网站，请一小时左右之后再试。</translation>
     </message>
     <message>
+        <location filename="../interface/UptimeTab.cpp" line="902"/>
         <location filename="../interface/UptimeTab.cpp" line="908"/>
-        <location filename="../interface/UptimeTab.cpp" line="914"/>
         <source>uptime and reboot data (all except per application) </source>
         <translation>上线和重启数据（除分应用之外） </translation>
     </message>
     <message>
+        <location filename="../interface/UptimeTab.cpp" line="903"/>
         <location filename="../interface/UptimeTab.cpp" line="909"/>
-        <location filename="../interface/UptimeTab.cpp" line="915"/>
         <source>Reset Uptime/Reboot History</source>
         <translation>重置上线时间 / 重启历史</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="919"/>
-        <location filename="../interface/UptimeTab.cpp" line="924"/>
+        <location filename="../interface/UptimeTab.cpp" line="913"/>
+        <location filename="../interface/UptimeTab.cpp" line="918"/>
         <source>application uptime data</source>
         <translation>应用上线时长数据</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="920"/>
-        <location filename="../interface/UptimeTab.cpp" line="925"/>
+        <location filename="../interface/UptimeTab.cpp" line="914"/>
+        <location filename="../interface/UptimeTab.cpp" line="919"/>
         <source>Reset Application History</source>
         <translation>重置应用历史</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="929"/>
+        <location filename="../interface/UptimeTab.cpp" line="923"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="931"/>
+        <location filename="../interface/UptimeTab.cpp" line="925"/>
         <source>Do you want to reset all uptime data or just the %1?</source>
         <translation>你是准备重置全部上线时长数据还是说只是%1？</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="934"/>
+        <location filename="../interface/UptimeTab.cpp" line="928"/>
         <source>Reset All Data</source>
         <translation>重置全部数据</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="949"/>
-        <location filename="../interface/UptimeTab.cpp" line="967"/>
-        <location filename="../interface/UptimeTab.cpp" line="985"/>
-        <location filename="../interface/UptimeTab.cpp" line="1000"/>
-        <location filename="../interface/UptimeTab.cpp" line="1008"/>
-        <location filename="../interface/UptimeTab.cpp" line="1025"/>
+        <location filename="../interface/UptimeTab.cpp" line="943"/>
+        <location filename="../interface/UptimeTab.cpp" line="961"/>
+        <location filename="../interface/UptimeTab.cpp" line="979"/>
+        <location filename="../interface/UptimeTab.cpp" line="994"/>
+        <location filename="../interface/UptimeTab.cpp" line="1002"/>
+        <location filename="../interface/UptimeTab.cpp" line="1019"/>
         <source>Delete stats?</source>
         <translation>删除统计？</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="950"/>
-        <location filename="../interface/UptimeTab.cpp" line="968"/>
+        <location filename="../interface/UptimeTab.cpp" line="944"/>
+        <location filename="../interface/UptimeTab.cpp" line="962"/>
         <source>Are you sure you want to delete all (except per application) recorded uptime statistics? This cannot be undone.</source>
         <translation>确定删除全部上线时长数据记录（除分应用之外）？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="986"/>
-        <location filename="../interface/UptimeTab.cpp" line="1009"/>
+        <location filename="../interface/UptimeTab.cpp" line="980"/>
+        <location filename="../interface/UptimeTab.cpp" line="1003"/>
         <source>Are you sure you want to delete all recorded per application uptime statistics? This cannot be undone.</source>
         <translation>确定删除全部分应用上线时长数据记录？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="1001"/>
+        <location filename="../interface/UptimeTab.cpp" line="995"/>
         <source>Are you sure you want to delete all recorded keyboard and mouse statistics? This cannot be undone.</source>
         <translation>确定删除全部键盘与鼠标统计记录？该操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../interface/UptimeTab.cpp" line="1026"/>
+        <location filename="../interface/UptimeTab.cpp" line="1020"/>
         <source>Are you sure you want to delete all recorded uptime statistics? This cannot be undone.</source>
         <translation>确定删除全部上线时长统计记录？该操作无法撤销。</translation>
     </message>
@@ -4783,140 +4788,141 @@ This will reset any custom layouts!</source>
         <translation>周六</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="982"/>
-        <location filename="../utils.cpp" line="1008"/>
+        <location filename="../utils.cpp" line="994"/>
+        <location filename="../utils.cpp" line="1020"/>
         <source>Save as...</source>
         <translation>另存为…</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="995"/>
-        <location filename="../utils.cpp" line="1023"/>
+        <location filename="../utils.cpp" line="1007"/>
+        <location filename="../utils.cpp" line="1035"/>
         <source>Export Failed</source>
         <translation>导出失败</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="996"/>
-        <location filename="../utils.cpp" line="1024"/>
+        <location filename="../utils.cpp" line="1008"/>
+        <location filename="../utils.cpp" line="1036"/>
         <source>Opening export file failed! Please try again in another directory.</source>
         <translation>打开导出文件失败！请使用其他目录重试。</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1034"/>
+        <location filename="../utils.cpp" line="1046"/>
         <source>Backspace</source>
         <translation>Backspace</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1037"/>
+        <location filename="../utils.cpp" line="1049"/>
         <source>Enter</source>
         <translation>Enter</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1040"/>
+        <location filename="../utils.cpp" line="1052"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1043"/>
+        <location filename="../utils.cpp" line="1055"/>
         <source>Capslock</source>
         <translation>Capslock</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1046"/>
+        <location filename="../utils.cpp" line="1058"/>
         <source>Left Shift</source>
         <translation>左 Shift</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1049"/>
+        <location filename="../utils.cpp" line="1061"/>
         <source>Left Control</source>
         <translation>左 Control</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1052"/>
+        <location filename="../utils.cpp" line="1064"/>
         <source>Left Alt</source>
         <translation>左 Alt</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1055"/>
+        <location filename="../utils.cpp" line="1067"/>
         <source>Right Alt</source>
         <translation>右 Alt</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1058"/>
+        <location filename="../utils.cpp" line="1070"/>
         <source>Right Control</source>
         <translation>右 Control</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1061"/>
+        <location filename="../utils.cpp" line="1073"/>
         <source>Right Shift</source>
         <translation>右 Shift</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1064"/>
+        <location filename="../utils.cpp" line="1076"/>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1067"/>
+        <location filename="../utils.cpp" line="1079"/>
         <source>Down</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1070"/>
+        <location filename="../utils.cpp" line="1082"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1073"/>
+        <location filename="../utils.cpp" line="1085"/>
         <source>Up</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1076"/>
+        <location filename="../utils.cpp" line="1088"/>
         <source>Insert</source>
         <translation>Insert</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1079"/>
+        <location filename="../utils.cpp" line="1091"/>
         <source>Home</source>
         <translation>Home</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1082"/>
+        <location filename="../utils.cpp" line="1094"/>
         <source>Page Up</source>
         <translation>Page Up</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1085"/>
+        <location filename="../utils.cpp" line="1097"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1088"/>
+        <location filename="../utils.cpp" line="1100"/>
         <source>End</source>
         <translation>End</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1091"/>
+        <location filename="../utils.cpp" line="1103"/>
         <source>Page Down</source>
         <translation>Page Down</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1094"/>
+        <location filename="../utils.cpp" line="1106"/>
         <source>Escape</source>
         <translation>Esc</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1136"/>
+        <location filename="../utils.cpp" line="1148"/>
         <source>Space</source>
         <translation>Space</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1253"/>
+        <location filename="../utils.cpp" line="1265"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../utils.cpp" line="1391"/>
+        <location filename="../utils.cpp" line="704"/>
+        <location filename="../utils.cpp" line="1403"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>


### PR DESCRIPTION
This is my ~~WIP~~updated to the 3.6 translation in Simplified Chinese (zh_CN) for WhatPulse.

It's my pleasure for contributing to this project.
I am coming from the "What's New" in 3.5, but I didn't receive a reply from sending a email for requesting the way of contributing translations (maybe in trashbin?), then I searched in Help Center and found here.

I am inside a company which technically denies employees from pushing to GitHub due to security reasons, so I have to use a mobile phone for translating.
Slow, but keep going.

There are 936 messages to translate. (`grep -c "<source>" whatpulse.ts.template`)
![](https://progress-bar.dev/936/?scale=936&width=120&title=Progress&color=007fff&suffix=/936)