### PR TITLE
Fix typo 'Pauze notifications' -> 'Pause notifications'

### DIFF
--- a/whatpulse_en.ts
+++ b/whatpulse_en.ts
@@ -3153,7 +3153,7 @@ Unpulsed: %2 down, %3 up</translation>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="277"/>
         <source>Pauze notifications</source>
-        <translation>Pauze notifications</translation>
+        <translation>Pause notifications</translation>
     </message>
     <message>
         <location filename="../interface/SettingsTab.cpp" line="325"/>


### PR DESCRIPTION
Fix for this small typo:
![image](https://user-images.githubusercontent.com/5573038/190259045-d162d364-3e7b-4782-af5a-3d2dc02b269b.png)

I wasn't sure if I should change all of the 'Source' fields to have this change as well, since I don't know how these strings are mapped. So I just left the source as-is for now and changed the translation.
